### PR TITLE
[POACC-527]

### DIFF
--- a/structure/syntax/ubl-catalogue.xml
+++ b/structure/syntax/ubl-catalogue.xml
@@ -27,7 +27,7 @@
 			<DataType>Identifier</DataType>
 			<Reference type="BUSINESS_TERM">tir19-001</Reference>
 			<Reference type="RULE">PEPPOL-T19-R017</Reference>
-			<Value type="EXAMPLE">urn:fdc:peppol.eu:poacc:bis:catalogue_only:3</Value>
+			<Value type="EXAMPLE">urn:fdc:peppol.eu:poacc:bis:catalogue_wo_response:3</Value>
 		</Element>
 		<Element>
 			<Term>cbc:ID</Term>


### PR DESCRIPTION
Editorial fix: Updated cbc:ProfileID description and example values in Order and Catalogue syntaxes to reflect the documentation and best practice.