### PR TITLE
Fixed casing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
 
-# PEPPOL BIS Upgrade
+# Peppol BIS Upgrade
 
-This repository is used for the PEPPOL BIS Upgrade project.
+This repository is used for the Peppol BIS Upgrade project.

--- a/guides/compliance/main.adoc
+++ b/guides/compliance/main.adoc
@@ -1,5 +1,5 @@
 = Compliance to BIS
-openPeppol AISBL <http://www.peppol.eu/>
+OpenPeppol AISBL <http://peppol.org/>
 :icons: font
 :source-highlighter: coderay
 :toc: left

--- a/guides/methodology/main.adoc
+++ b/guides/methodology/main.adoc
@@ -1,7 +1,7 @@
 include::links.adoc[]
 
 = image:../shared/images/peppol.png[float="right"]Peppol Documentation Methodology
-OpenPeppol AISBL, Post-Award Coordinating Community
+OpenPeppol AISBL, Post-Award Community
 v0.1.0
 :doctype: book
 :icons: font

--- a/guides/methodology/schematron/main.adoc
+++ b/guides/methodology/schematron/main.adoc
@@ -10,7 +10,7 @@
 :sectnums:
 :last-update-label!:
 
-This document gives a guidance in how to develop schematron artefacts in openPeppol Post Award Coordinating Community.
+This document gives a guidance in how to develop schematron artefacts in OpenPeppol Post Award Community.
 
 NOTE: This document is work in progress and will be further developed. If you have any feedback, please provide them as an issue in https://github.com/OpenPEPPOL/poacc-upgrade-3/issues[GitHub].
 

--- a/guides/migration/main.adoc
+++ b/guides/migration/main.adoc
@@ -2,7 +2,7 @@ include::../shared/links.adoc[]
 include::settings.adoc[]
 
 = Migration plan
-Draft, OpenPeppol AISBL, Post-Award Coordinating Community
+Draft, OpenPeppol AISBL, Post-Award Community
 :doctype: book
 :icons: font
 :toc: left

--- a/guides/migration/overview.adoc
+++ b/guides/migration/overview.adoc
@@ -15,7 +15,7 @@ This migration plan addresses the migration of the Peppol BIS specifications fro
 * BIS 63A Invoice Response
 
 A - Phase In::
-* “Phase in” is defined as the start date for the optional use of Peppol BIS version 3.0 specifications corresponding to the publication date when the new Peppol BIS specifications become available for download at www.peppol.eu.
+* “Phase in” is defined as the start date for the optional use of Peppol BIS version 3.0 specifications corresponding to the publication date when the new Peppol BIS specifications become available for download at peppol.org.
 * The date is set to *{phase-in}*
 
 B - Transition::

--- a/guides/profiles/1-catalogueonly/introduction/index.adoc
+++ b/guides/profiles/1-catalogueonly/introduction/index.adoc
@@ -1,7 +1,7 @@
 [[introduction-to-openpeppol-and-bis]]
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
-This BIS is a result of work within openPeppol and is published as part of the Peppol specifications.
+This BIS is a result of work within OpenPeppol and is published as part of the Peppol specifications.
 
 This Peppol BIS provides a set of specifications for implementing a Peppol business process.
 The document is concerned with clarifying requirements for ensuring interoperability of pan-European Public eProcurement and provides guidelines for supporting these requirements and how to implement them.

--- a/guides/profiles/18-punchout/introduction/index.adoc
+++ b/guides/profiles/18-punchout/introduction/index.adoc
@@ -1,5 +1,5 @@
 
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/18-punchout/requirements/peppol-requirements.adoc
+++ b/guides/profiles/18-punchout/requirements/peppol-requirements.adoc
@@ -2,7 +2,7 @@
 = Specific OpenPeppol requirements
 
 [cols="1,2,3",options="header"]
-.Specific openPeppol requirements
+.Specific OpenPeppol requirements
 |====
 |ID:
 |Business term:

--- a/guides/profiles/28-ordering/introduction/index.adoc
+++ b/guides/profiles/28-ordering/introduction/index.adoc
@@ -1,5 +1,5 @@
 
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/3-order-only/introduction/index.adoc
+++ b/guides/profiles/3-order-only/introduction/index.adoc
@@ -1,5 +1,5 @@
 
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/30-despatchadvice/introduction/index.adoc
+++ b/guides/profiles/30-despatchadvice/introduction/index.adoc
@@ -1,5 +1,5 @@
 [[introduction-to-openpeppol-and-bis]]
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within Peppol project and is published as part of Peppol specifications.
 

--- a/guides/profiles/36-mlr/introduction/index.adoc
+++ b/guides/profiles/36-mlr/introduction/index.adoc
@@ -1,5 +1,5 @@
 
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/42-orderagreement/introduction/index.adoc
+++ b/guides/profiles/42-orderagreement/introduction/index.adoc
@@ -1,5 +1,5 @@
 
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/63-invoiceresponse/introduction/index.adoc
+++ b/guides/profiles/63-invoiceresponse/introduction/index.adoc
@@ -1,6 +1,6 @@
 
 [[introduction-to-openpeppol-and-bis]]
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 

--- a/guides/profiles/64-catalogue-wo-response/introduction/index.adoc
+++ b/guides/profiles/64-catalogue-wo-response/introduction/index.adoc
@@ -1,7 +1,7 @@
 [[introduction-to-openpeppol-and-bis]]
-= Introduction to openPeppol and BIS
+= Introduction to OpenPeppol and BIS
 
-This BIS is a result of work within openPeppol and is published as part of the Peppol specifications.
+This BIS is a result of work within OpenPeppol and is published as part of the Peppol specifications.
 
 This Peppol BIS provides a set of specifications for implementing a Peppol business process.
 The document is concerned with clarifying requirements for ensuring interoperability of pan-European Public eProcurement and provides guidelines for supporting these requirements and how to implement them.

--- a/guides/profiles/65-advanced-ordering/introduction/index.adoc
+++ b/guides/profiles/65-advanced-ordering/introduction/index.adoc
@@ -1,7 +1,7 @@
 
 = Introduction to OpenPeppol and BIS
 
-This BIS is a result of work within {openPeppol} and is published as part of the {Peppol} specifications.
+This BIS is a result of work within {OpenPeppol} and is published as part of the {Peppol} specifications.
 
 This BIS provides a set of specifications for implementing a {Peppol} business process.
 The document is concerned with clarifying requirements for ensuring interoperability of pan-European Public eProcurement and provides guidelines for supporting these requirements and how to implement them.

--- a/guides/profiles/99-Sandbox/codelists/index.adoc
+++ b/guides/profiles/99-Sandbox/codelists/index.adoc
@@ -2,7 +2,7 @@
 [[codelist]]
 = Code lists
 
-The following chapters give an overview of the codes that is used in this PEPPOL BIS.
+The following chapters give an overview of the codes that is used in this Peppol BIS.
 
 :leveloffset: +1
 

--- a/guides/profiles/99-Sandbox/codelists/schemes/endpoint.adoc
+++ b/guides/profiles/99-Sandbox/codelists/schemes/endpoint.adoc
@@ -4,7 +4,7 @@
 
 Electronic address identifiers (Endpoint identification) use of a code list to be maintained by CEF.
 
-#This code list is still not available. Use PEPPOL Policy for identifiers#
+#This code list is still not available. Use Peppol Policy for identifiers#
 
 [cols="2,3,3", options="header"]
 |===

--- a/guides/profiles/99-Sandbox/introduction/index.adoc
+++ b/guides/profiles/99-Sandbox/introduction/index.adoc
@@ -1,16 +1,16 @@
 
-= Introduction to openPEPPOL and BIS
+= Introduction to OpenPeppol and BIS
 
 This BIS is a result of work within {openpeppol} and is published as part of the {peppol} specifications.
 
-This PEPPOL BIS provides a set of specifications for implementing a {peppol} business process.
+This Peppol BIS provides a set of specifications for implementing a {peppol} business process.
 The document is concerned with clarifying requirements for ensuring interoperability of pan-European Public eProcurement and provides guidelines for supporting these requirements and how to implement them.
-This PEPPOL BIS is based on the {bii-mlr}. #A conformance statement is included in this BIS, see annex D.#
+This Peppol BIS is based on the {bii-mlr}. #A conformance statement is included in this BIS, see annex D.#
 
 *The purpose* of this document is to describe a common format for the message level response message in the European market, and to facilitate an efficient implementation and increased use of electronic collaboration regarding the message level response process based on this format.
 
 
-.Relationship between BII profiles and PEPPOL BIS
+.Relationship between BII profiles and Peppol BIS
 image::../../shared/images/BII_relationship.png[]
 
 

--- a/guides/profiles/99-Sandbox/main.adoc
+++ b/guides/profiles/99-Sandbox/main.adoc
@@ -1,9 +1,9 @@
 include::../../shared/links.adoc[]
 
 = image:../../shared/images/peppol.png[float="right"]BIS Message Level Response - 36A
-OpenPEPPOL AISBL, Post-Award Coordinating Community
+OpenPeppol AISBL, Post-Award Community
 v3.0.0
-:description: The PEPPOL Business Interoperability Specification, “BIS” from here on after, has been developed by the OpenPEPPOL AISBL Post Award Coordinating Community and is published as part of the PEPPOL specifications.
+:description: The PEPPOL Business Interoperability Specification, “BIS” from here on after, has been developed by the OpenPeppol AISBL Post Award Community and is published as part of the Peppol specifications.
 :doctype: book
 :icons: font
 :stem:

--- a/guides/profiles/99-Sandbox/principles/parties.adoc
+++ b/guides/profiles/99-Sandbox/principles/parties.adoc
@@ -3,7 +3,7 @@
 
 The table below gives the definitions of the parties and roles of the message level response process.
 The sender and receiver of the Message Level Response message should be extracted from the
-envelope, i.e. the PEPPOL participants.
+envelope, i.e. the Peppol participants.
 
 [cols="2,4"]
 |====

--- a/guides/profiles/99-Sandbox/principles/principles/index.adoc
+++ b/guides/profiles/99-Sandbox/principles/principles/index.adoc
@@ -2,7 +2,7 @@
 [[principles]]
 = Principles and prerequisites
 
-This chapter describes the principles and assumptions that underlie the use of this PEPPOL BIS Punch out.
+This chapter describes the principles and assumptions that underlie the use of this Peppol BIS Punch out.
 It is based on the {bii} 18 Punch out.
 
 This document identifies, explains and justifies the business requirements for the Punch Out-process.

--- a/guides/profiles/99-Sandbox/principles/principles/scope.adoc
+++ b/guides/profiles/99-Sandbox/principles/principles/scope.adoc
@@ -14,4 +14,4 @@ In this BIS, synchronization of shopping cart transaction information covers the
 In case of an update/change, the buyer will simply generate a new product- or service list by repeating the process.
 
 The information sourced with the Punch Out BIS may be used in following business process, such as ordering.
-The order transaction is outside scope of this BIS, we then refer to BISs PEPPOL BIS 3A Order Only or PEPPOL BIS 28A Ordering.
+The order transaction is outside scope of this BIS, we then refer to BISs Peppol BIS 3A Order Only or Peppol BIS 28A Ordering.

--- a/guides/profiles/99-Sandbox/profile/identifiers.adoc
+++ b/guides/profiles/99-Sandbox/profile/identifiers.adoc
@@ -1,7 +1,7 @@
 [[namespaces]]
 = Namespaces
 
-The message level response data model is in this PEPPOL BIS bound to the {ubl-appl-resp}. The target namespace for the UBL-ApplicationResponse-2.1 is:
+The message level response data model is in this Peppol BIS bound to the {ubl-appl-resp}. The target namespace for the UBL-ApplicationResponse-2.1 is:
 
 `urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2`
 

--- a/guides/profiles/99-Sandbox/rules/codelist.adoc
+++ b/guides/profiles/99-Sandbox/rules/codelist.adoc
@@ -12,18 +12,18 @@
 |Fatal
 
 |CL-071-R002
-|A Response Code MUST be from the UNCL 4343 PEPPOL Subset code list
+|A Response Code MUST be from the UNCL 4343 Peppol Subset code list
 |Fatal
 
 |OP-T71-R001
-|An Endpoint Identifier Scheme MUST be from the list of PEPPOL Party Identifiers described in the "PEPPOL Policy for using Identifiers".
+|An Endpoint Identifier Scheme MUST be from the list of Peppol Party Identifiers described in the "Peppol Policy for using Identifiers".
 |Fatal
 
 |OP-T71-R002
-|An Party Identifier Scheme MUST be from the list of PEPPOL Party Identifiers described in the "PEPPOL Policy for using Identifiers".
+|An Party Identifier Scheme MUST be from the list of Peppol Party Identifiers described in the "Peppol Policy for using Identifiers".
 |Fatal
 
 |OP-071-R003
-|A message level response MUST specify the status reason code using the PEPPOL Status code list
+|A message level response MUST specify the status reason code using the Peppol Status code list
 |Fatal
 |====

--- a/guides/profiles/99-Sandbox/rules/peppol.adoc
+++ b/guides/profiles/99-Sandbox/rules/peppol.adoc
@@ -1,5 +1,5 @@
 [[peppol-specific-rules]]
-== PEPPOL Specific rules
+== Peppol Specific rules
 
 [cols="1s,4,1",options="header"]
 |====

--- a/guides/release-notes/main.adoc
+++ b/guides/release-notes/main.adoc
@@ -1,5 +1,5 @@
 = Release notes for Peppol BIS 3 documents, other than Peppol BIS Billing 3.0
-openPeppol AISBL <http://www.peppol.eu/>
+OpenPeppol AISBL <https://peppol.org/>
 :icons: font
 :source-highlighter: coderay
 :toc: left

--- a/guides/release-notes/v3.0.1.adoc
+++ b/guides/release-notes/v3.0.1.adoc
@@ -4,7 +4,7 @@ Release date:: 2019-05-15
 
 [NOTE]
 ====
-This release is a backward compatible minor upgrade, version 3.0.1 replacing the previous version 3.0.0 of OpenPEPPOL BIS document, other than the BIS Billing 3.0. The release includes changes to the BIS documents as well as the validation artifacts (VA's).
+This release is a backward compatible minor upgrade, version 3.0.1 replacing the previous version 3.0.0 of OpenPeppol BIS document, other than the BIS Billing 3.0. The release includes changes to the BIS documents as well as the validation artifacts (VA's).
 ====
 
 == Changes to BIS documents and validation artifacts

--- a/guides/release-notes/v3.0.4.adoc
+++ b/guides/release-notes/v3.0.4.adoc
@@ -4,8 +4,8 @@ Release date:: 2020-05-01
 
 == Changes to BIS document
 * The code example in section 6.6 (Classification) is updated from the temporary code ”MC” to the code “TST” (The UNSPSC commodity classification system) from code list UCL7143. [POACC-274]
-** for PEPPOL BIS Catalogue without response 3
-** for PEPPOL BIS Catalogue only 3
+** for Peppol BIS Catalogue without response 3
+** for Peppol BIS Catalogue only 3
 * Following BIS generalized so that they use term TAX instead of VAT. Enables using them for other similar taxes like GST. Catalogue, Catalogue only, Order, Ordering, Order Agreement, Punch Out, Invoice Response. [POACC-265]
 ** Text in guidelines generalized from VAT to GST
 ** Element names and descriptions that had VAT in them generalized as TAX

--- a/guides/shared/links.adoc
+++ b/guides/shared/links.adoc
@@ -1,6 +1,6 @@
 //description and subheading text
-:description: The Peppol Business Interoperability Specification, “BIS” from here on after, has been developed by the OpenPeppol AISBL Post Award Coordinating Community and is published as part of the Peppol specifications.
-:author: OpenPeppol AISBL, Post-Award Coordinating Community
+:description: The Peppol Business Interoperability Specification, “BIS” from here on after, has been developed by the OpenPeppol AISBL Post Award Community and is published as part of the Peppol specifications.
+:author: OpenPeppol AISBL, Post-Award Community
 :version: 3.0.3
 :ord_version: 3.1.0
 //Peppol

--- a/guides/shared/links.adoc
+++ b/guides/shared/links.adoc
@@ -4,12 +4,12 @@
 :version: 3.0.3
 :ord_version: 3.1.0
 //Peppol
-:peppol: https://peppol.eu/?rel=undefined[Peppol]
+:peppol: https://peppol.org/[Peppol]
 :common: https://joinup.ec.europa.eu/svn/peppol/PEPPOL%20BIS%20Common%20text%20and%20introduction%20-%20ver%201%202014-04-14.pdf[Peppol BIS common text and introduction]
-:openpeppol: https://peppol.eu/about-openpeppol/?rel=tab41[OpenPeppol]
-:policy8: https://peppol.eu/downloads/the-peppol-edelivery-network-specifications/[Peppol Policy for identifiers, policy 8]
+:openpeppol: https://peppol.org/learn-more/organisation/[OpenPeppol]
+:policy8: https://docs.peppol.eu/edelivery/[Peppol Policy for identifiers, policy 8]
 :migration-policy: https://github.com/OpenPEPPOL/documentation/blob/master/LifecycleManagement/ReleaseManagement/Migration%20Policy%20-%20Common%20Document%202014-02-24%20rev%202014-08-27.pdf[OpenPeppol Migration Policy]
-:peppol-transport: https://peppol.eu/downloads/the-peppol-edelivery-network-specifications/[Peppol eDelivery Network Specifications]
+:peppol-transport: https://peppol.org/documentation/technical-documentation/edelivery-documentation/[Peppol eDelivery Network Specifications]
 :peppol-billing: http://docs.peppol.eu/poacc/billing/3.0/[Peppol BIS Billing 3.0]
 :main-site: link:/poacc/upgrade-3/[Main documentation site]
 

--- a/guides/transactions/114-order-change/codelists/index.adoc
+++ b/guides/transactions/114-order-change/codelists/index.adoc
@@ -2,7 +2,7 @@
 [[codelist]]
 = Code lists
 
-The following chapters give an overview of the codes that is used in this PEPPOL BIS. 
+The following chapters give an overview of the codes that is used in this Peppol BIS. 
 
 :leveloffset: +1
 

--- a/guides/transactions/114-order-change/requirements/peppol.adoc
+++ b/guides/transactions/114-order-change/requirements/peppol.adoc
@@ -1,4 +1,4 @@
-[[specific-openPeppol-requirements]]
+[[specific-openpeppol-requirements]]
 = Specific OpenPeppol requirements
 
 [cols="1,1,4",options="header"]

--- a/guides/transactions/114-order-change/rules/codelist.adoc
+++ b/guides/transactions/114-order-change/rules/codelist.adoc
@@ -4,11 +4,11 @@
 [cols="1s,5",options="header"]
 |====
 |Identifier |Business Rule
-|OP-T01-001 |OrderTypeCode MUST be from UN/ECE 1001 code list PEPPOL Subset
+|OP-T01-001 |OrderTypeCode MUST be from UN/ECE 1001 code list Peppol Subset
 |OP-T01-002 |DocumentCurrencyCode MUST be coded using ISO code list 4217
 |OP-T01-003 |A Binary Object MIME code attribute MUST be coded using MIME Code Type version 2008 code list
-|OP-T01-004 |An Endpoint Identifier Scheme identifier MUST be from the code list PEPPOL Party Identifier
-|OP-T01-005 |An Party Identifier Scheme identifier MUST be from the code list PEPPOL Party Identifier
+|OP-T01-004 |An Endpoint Identifier Scheme identifier MUST be from the code list Peppol Party Identifier
+|OP-T01-005 |An Party Identifier Scheme identifier MUST be from the code list Peppol Party Identifier
 |OP-T01-006 |Country codes in an order MUST be coded using ISO code list 3166-1
 |OP-T01-007 |currencyID MUST be coded using ISO code list 4217
 |OP-T01-008 |A tax category identifier MUST be coded using UN/ECE 5305 BII2 Subset

--- a/guides/transactions/115-order-cancellation/codelists/index.adoc
+++ b/guides/transactions/115-order-cancellation/codelists/index.adoc
@@ -2,7 +2,7 @@
 [[codelist]]
 = Code lists
 
-The following chapters give an overview of the codes that is used in this PEPPOL BIS. 
+The following chapters give an overview of the codes that is used in this Peppol BIS. 
 
 :leveloffset: +1
 

--- a/guides/transactions/115-order-cancellation/codelists/schemes/endpoint.adoc
+++ b/guides/transactions/115-order-cancellation/codelists/schemes/endpoint.adoc
@@ -4,7 +4,7 @@
 
 Electronic address identifiers (Endpoint identification) use of a code list to be maintained by CEF.
 
-#This code list is still not available. Use PEPPOL Policy for identifiers#
+#This code list is still not available. Use Peppol Policy for use of identifiers#
 
 [cols="2,3,3", options="header"]
 |===

--- a/guides/transactions/115-order-cancellation/requirements/peppol.adoc
+++ b/guides/transactions/115-order-cancellation/requirements/peppol.adoc
@@ -1,5 +1,5 @@
 [[specific-openpeppol-requirements]]
-= Specific OpenPEPPOL requirements
+= Specific OpenPeppol requirements
 
 [cols="1,1,4",options="header"]
 |====
@@ -37,5 +37,5 @@ Swedish requirement.
 |OP-T01-013
 |AdditionalItemProperty: +
 Value quantity and value qualifier 
-|Value quantity and value qualifier has been added to the AdditionalItemProperty element to harmonise with PEPPOL BIS Catalogue.
+|Value quantity and value qualifier has been added to the AdditionalItemProperty element to harmonise with Peppol BIS Catalogue.
 |====

--- a/guides/transactions/115-order-cancellation/rules/codelist.adoc
+++ b/guides/transactions/115-order-cancellation/rules/codelist.adoc
@@ -4,11 +4,11 @@
 [cols="1s,5",options="header"]
 |====
 |Identifier |Business Rule
-|OP-T01-001 |OrderTypeCode in an order MUST be from UN/ECE 1001 code list PEPPOL Subset
+|OP-T01-001 |OrderTypeCode in an order MUST be from UN/ECE 1001 code list Peppol Subset
 |OP-T01-002 |DocumentCurrencyCode MUST be coded using ISO code list 4217
 |OP-T01-003 |A Binary Object MIME code attribute MUST be coded using MIME Code Type version 2008 code list
-|OP-T01-004 |An Endpoint Identifier Scheme identifier MUST be from the code list PEPPOL Party Identifier
-|OP-T01-005 |An Party Identifier Scheme identifier MUST be from the code list PEPPOL Party Identifier
+|OP-T01-004 |An Endpoint Identifier Scheme identifier MUST be from the code list Peppol Party Identifier
+|OP-T01-005 |An Party Identifier Scheme identifier MUST be from the code list Peppol Party Identifier
 |OP-T01-006 |Country codes in an order MUST be coded using ISO code list 3166-1
 |OP-T01-007 |currencyID MUST be coded using ISO code list 4217
 |OP-T01-008 |A tax category identifier MUST be coded using UN/ECE 5305 BII2 Subset

--- a/rules/examples/DespatchAdvice_Example.xml
+++ b/rules/examples/DespatchAdvice_Example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a Full BIS3 PEPPOL UBL Despatch Adivce.
+                This file contains a Full BIS3 Peppol UBL Despatch Adivce.
 
                 Errors:
                 None

--- a/rules/examples/Invoice reponse use cases/T111-uc001-Invoice in process.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc001-Invoice in process.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 1 — Invoice in process
 
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc002a-Additional reference data.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc002a-Additional reference data.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 2a — Invoice in process with additional reference date.
 				
 				Use case shows an invoice that is in process and states the date when the invoice was received and entered into processing which in this case is shown as a day before the IMR is sent. 

--- a/rules/examples/Invoice reponse use cases/T111-uc002b-In process but postponed.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc002b-In process but postponed.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 2b — Invoice is in process but processing is postponed.
 				
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc003-Invoice is accepted.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc003-Invoice is accepted.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 3 — Invoice is accepted
 
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc004a-Invoice is rejected.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc004a-Invoice is rejected.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 4a — Invoice is rejected
 
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc004b-Rejected requesting reissue.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc004b-Rejected requesting reissue.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 4b — Invoice is rejected requesting re-issue 
 				
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc004c-Rejected requesting replacement.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc004c-Rejected requesting replacement.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 4c — Invoice is rejected requesting replacement. 
 				
                 Errors:

--- a/rules/examples/Invoice reponse use cases/T111-uc005-Invoice is conditionally accepted.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc005-Invoice is conditionally accepted.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 5 — Invoice is rejected requesting replacement. 
 				
 				The buyer sets a new due date as 2018-01-15 using the Business term identifier BT-9 for Due Date as defined in EN 16931 

--- a/rules/examples/Invoice reponse use cases/T111-uc006a-Under query missing information.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc006a-Under query missing information.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 6a — Invoice is under query because of wrong or missing information. 
 				
 				The use case assumes missing purchase order reference and proposes that the reference should be PO0001, the invoice is put under query 2 days after it was issued.

--- a/rules/examples/Invoice reponse use cases/T111-uc006b-Missing PO.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc006b-Missing PO.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 6a — Invoice is under query because of wrong or missing information. 
 				
 				The use case assumes missing purchase order reference and proposes that the reference should be PO0001, the invoice is put under query 2 days after it was issued.

--- a/rules/examples/Invoice reponse use cases/T111-uc006c-Wrong detail partial credit.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc006c-Wrong detail partial credit.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 6c — Invoice is under query because of wrong detail. Partial credit note is requested. 
 				
 				Use case demonstrates how line level corrections are given with textual notes.

--- a/rules/examples/Invoice reponse use cases/T111-uc007-Payment has been initiated.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc007-Payment has been initiated.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 7 — Payment has been initiated. 
 
 				Use case shows where payment has been initated on 2017-12-30.		

--- a/rules/examples/Invoice reponse use cases/T111-uc008-Invoice is accepted by third party.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc008-Invoice is accepted by third party.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a PEPPOL Invoice Message Response, profile 63.
+                This file contains a Peppol Invoice Message Response, profile 63.
 				It demonstrates Use Case 8 — Invoice is accepted by third party who acts on behalf of Buyer. 
 				
 				Use case shows where Invoice processing service sends an acceptance to the Seller company for an invoice that was issued to Buyer A..		

--- a/rules/examples/InvoiceResponse_Example.xml
+++ b/rules/examples/InvoiceResponse_Example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a Full BIS3 PEPPOL UBL Invoice Response.
+                This file contains a Full BIS3 Peppol UBL Invoice Response.
 
                 Errors:
                 None

--- a/rules/examples/MessageLevelResponse_Example.xml
+++ b/rules/examples/MessageLevelResponse_Example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a Full BIS3 PEPPOL UBL MLR.
+                This file contains a Full BIS3 Peppol UBL MLR.
 
                 Errors:
                 None

--- a/rules/examples/OrderAgreement_Example.xml
+++ b/rules/examples/OrderAgreement_Example.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
                 Content:
-                This file contains a Full BIS3 PEPPOL UBL Order Agreement
+                This file contains a Full BIS3 Peppol UBL Order Agreement
 
                 Errors:
                 None

--- a/rules/sch/PEPPOLBIS-T01.sch
+++ b/rules/sch/PEPPOLBIS-T01.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order transaction 3.4</title>
+    <title>Rules for Peppol Order transaction 3.4</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T110.sch
+++ b/rules/sch/PEPPOLBIS-T110.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order Agreement transaction 3.1</title>
+    <title>Rules for Peppol Order Agreement transaction 3.1</title>
 
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T111.sch
+++ b/rules/sch/PEPPOLBIS-T111.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Invoice Response transaction 3.1</title>
+    <title>Rules for Peppol Invoice Response transaction 3.1</title>
 
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T114.sch
+++ b/rules/sch/PEPPOLBIS-T114.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order Change transaction 3.0</title>
+    <title>Rules for Peppol Order Change transaction 3.0</title>
 
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T115.sch
+++ b/rules/sch/PEPPOLBIS-T115.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order Cancellation transaction 3.0</title>
+    <title>Rules for Peppol Order Cancellation transaction 3.0</title>
 
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T116.sch
+++ b/rules/sch/PEPPOLBIS-T116.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order Response Advanced transaction 3.0</title>
+    <title>Rules for Peppol Order Response Advanced transaction 3.0</title>
 
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T16.sch
+++ b/rules/sch/PEPPOLBIS-T16.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Despatch Advice transaction 3.2</title>
+    <title>Rules for Peppol Despatch Advice transaction 3.2</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T19.sch
+++ b/rules/sch/PEPPOLBIS-T19.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Catalogue transaction 3.2</title>
+    <title>Rules for Peppol Catalogue transaction 3.2</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T58.sch
+++ b/rules/sch/PEPPOLBIS-T58.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Catalogue Response transaction 3.0</title>
+    <title>Rules for Peppol Catalogue Response transaction 3.0</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T71.sch
+++ b/rules/sch/PEPPOLBIS-T71.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Message Level Response transaction 3.0</title>
+    <title>Rules for Peppol Message Level Response transaction 3.0</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T76.sch
+++ b/rules/sch/PEPPOLBIS-T76.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Order Response transaction 3.2</title>
+    <title>Rules for Peppol Order Response transaction 3.2</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/PEPPOLBIS-T77.sch
+++ b/rules/sch/PEPPOLBIS-T77.sch
@@ -3,7 +3,7 @@
         xmlns:xi="http://www.w3.org/2001/XInclude"
         schemaVersion="iso" queryBinding="xslt2">
 
-    <title>Rules for PEPPOL Punch Out transaction 3.2</title>
+    <title>Rules for Peppol Punch Out transaction 3.2</title>
     
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
     <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/rules/sch/parts/common.sch
+++ b/rules/sch/parts/common.sch
@@ -2,7 +2,7 @@
 <schema xmlns="http://purl.oclc.org/dsdl/schematron" xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:u="utils"
         schemaVersion="iso" queryBinding="xslt2">
 
-  <title>Common PEPPOL rules for Post-Award</title>
+  <title>Common Peppol rules for Post-Award</title>
 
   <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2" prefix="cbc"/>
   <ns uri="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2" prefix="cac"/>

--- a/structure/codelist/ActionCode_header.xml
+++ b/structure/codelist/ActionCode_header.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Catalogue Action code, header level (openPEPPOL)</Title>
+    <Title>Catalogue Action code, header level (OpenPeppol)</Title>
     <Identifier>ActionCode_header</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Agency>OpenPeppol</Agency>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>Add</Id>

--- a/structure/codelist/ActionCode_line.xml
+++ b/structure/codelist/ActionCode_line.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Catalogue Action code, line level (openPEPPOL)</Title>
+    <Title>Catalogue Action code, line level (OpenPeppol)</Title>
     <Identifier>ActionCode_line</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Agency>OpenPeppol</Agency>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>Add</Id>

--- a/structure/codelist/ClarificationListID.xml
+++ b/structure/codelist/ClarificationListID.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Clarification list identifier (openPEPPOL)</Title>
+    <Title>Clarification list identifier (OpenPeppol)</Title>
     <Identifier>ClarificationListID</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Agency>OpenPeppol</Agency>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>OPStatusAction</Id>

--- a/structure/codelist/GS17009.xml
+++ b/structure/codelist/GS17009.xml
@@ -5,7 +5,7 @@
     <Identifier>GS17009</Identifier>
     <Version>1.0</Version>
     <Agency>GS1</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>CU</Id>

--- a/structure/codelist/Image.xml
+++ b/structure/codelist/Image.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Image code (openPEPPOL)</Title>
+    <Title>Image code (OpenPeppol)</Title>
     <Identifier>Image</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
+    <Agency>OpenPeppol</Agency>
 
 <!-- The code values in this list are based on the GS1 GDD list for ReferencedFileTypeCode -->
 

--- a/structure/codelist/MimeCode.xml
+++ b/structure/codelist/MimeCode.xml
@@ -5,7 +5,7 @@
     <Identifier>MimeCode</Identifier>
     <Version>1.0</Version>
     <Agency>IANA</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
 
 

--- a/structure/codelist/OPStatusAction.xml
+++ b/structure/codelist/OPStatusAction.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Status Clarification Action (OpenPEPPOL)</Title>
+    <Title>Status Clarification Action (OpenPeppol)</Title>
     <Identifier>OPStatusAction</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
+    <Agency>OpenPeppol</Agency>
 
 
     <Code>

--- a/structure/codelist/OPStatusReason.xml
+++ b/structure/codelist/OPStatusReason.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Status Clarification Reason (OpenPEPPOL)</Title>
+    <Title>Status Clarification Reason (OpenPeppol)</Title>
     <Identifier>OPStatusReason</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
+    <Agency>OpenPeppol</Agency>
 
 
     <Code>

--- a/structure/codelist/StatusReason.xml
+++ b/structure/codelist/StatusReason.xml
@@ -1,10 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Status reason code (openPEPPOL)</Title>
+    <Title>Status reason code (OpenPeppol)</Title>
     <Identifier>StatusReason</Identifier>
     <Version>3.0</Version>
-    <Agency>openPEPPOL</Agency>
+    <Agency>OpenPeppol</Agency>
 
 
     <Code>

--- a/structure/codelist/TransactionConditions.xml
+++ b/structure/codelist/TransactionConditions.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Transaction condition code (OpenPEPPOL)</Title>
+    <Title>Transaction condition code (OpenPeppol)</Title>
     <Identifier>TransactionCondition</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Agency>OpenPeppol</Agency>
+    <Subset>OpenPeppol</Subset>
 
 	<Code>
         <Id>CT</Id>

--- a/structure/codelist/TrueFalse.xml
+++ b/structure/codelist/TrueFalse.xml
@@ -1,11 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <CodeList xmlns="urn:fdc:difi.no:2017:vefa:structure:CodeList-1">
 
-    <Title>Boolean indicator (openPEPPOL)</Title>
+    <Title>Boolean indicator (OpenPeppol)</Title>
     <Identifier>TrueFalse</Identifier>
     <Version>1.0</Version>
-    <Agency>OpenPEPPOL</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Agency>OpenPeppol</Agency>
+    <Subset>OpenPeppol</Subset>
 
 
     <Code>

--- a/structure/codelist/UNCL1001_T01.xml
+++ b/structure/codelist/UNCL1001_T01.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL1001_T01</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
      <Code>
         <Id>105</Id>

--- a/structure/codelist/UNCL1225.xml
+++ b/structure/codelist/UNCL1225.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL1225</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>27</Id>

--- a/structure/codelist/UNCL1229.xml
+++ b/structure/codelist/UNCL1229.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL1229</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>1</Id>

--- a/structure/codelist/UNCL1229_CHANGE.xml
+++ b/structure/codelist/UNCL1229_CHANGE.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL1229_CHANGE</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>1</Id>

--- a/structure/codelist/UNCL4219.xml
+++ b/structure/codelist/UNCL4219.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL4219</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>1</Id>

--- a/structure/codelist/UNCL4343-T111.xml
+++ b/structure/codelist/UNCL4343-T111.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL4343-T111</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL-InvoiceResponse</Subset>
+    <Subset>OpenPeppol-InvoiceResponse</Subset>
     
     <Code>
         <Id>AB</Id>

--- a/structure/codelist/UNCL4343-T76.xml
+++ b/structure/codelist/UNCL4343-T76.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL4343-T76</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>AB</Id>

--- a/structure/codelist/UNCL4343.xml
+++ b/structure/codelist/UNCL4343.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL4343</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>AB</Id>

--- a/structure/codelist/UNCL5189.xml
+++ b/structure/codelist/UNCL5189.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL5189</Identifier>
     <Version>D.16B</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
 
 

--- a/structure/codelist/UNCL5305.xml
+++ b/structure/codelist/UNCL5305.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL5305</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>OpenPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
     <Code>
         <Id>AE</Id>

--- a/structure/codelist/UNCL6313-T16.xml
+++ b/structure/codelist/UNCL6313-T16.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL6313-T16</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
 
     <Code>

--- a/structure/codelist/UNCL6313.xml
+++ b/structure/codelist/UNCL6313.xml
@@ -5,7 +5,7 @@
     <Identifier>UNCL6313</Identifier>
     <Version>D.17A</Version>
     <Agency>UN/CEFACT</Agency>
-    <Subset>openPEPPOL</Subset>
+    <Subset>OpenPeppol</Subset>
 
 
     <Code>


### PR DESCRIPTION
This PR fixes the casing to use
* `Peppol` as the network
* `OpenPeppol` as the organisation

Removed the `Coordinating` from `Coordinating Community`

Also trying to use "peppol.org" instead of "peppol.eu" if there was an easy replacement