### PR TITLE
Adjusted profile 63 to support self-billing with response.

### DIFF
--- a/guides/profiles/63-invoiceresponse/descriptions/doc-ref.adoc
+++ b/guides/profiles/63-invoiceresponse/descriptions/doc-ref.adoc
@@ -1,12 +1,13 @@
 [[document-reference]]
 = Document reference
 
-Used to provide a reference to the business document e.g. the invoice or credit note, to which the Invoice Response is is responding.
+Used to provide a reference to the business document, e.g. the invoice, self-billed invoice, or credit note, to which the Invoice Response is responding.
 
 IMPORTANT: One Invoice Response may only reference one business document.
 
 The type of the business document must also be included in the document reference element.
 Document Type Code is coded according to code list 1001 issued by UN/CEFACT.
+For a self-billed invoice, the Document Type Code is `389`.
 
 See chapter {link-codelist} for a complete list of all the document types.
 

--- a/guides/profiles/63-invoiceresponse/descriptions/parties.adoc
+++ b/guides/profiles/63-invoiceresponse/descriptions/parties.adoc
@@ -3,18 +3,20 @@
 
 The sending and receiving parties are those that exchange the Invoice Response.
 These may be the Buyer and the Seller or service providers acting on their behalf.
+In standard billing, the Buyer is the sender and the Seller is the receiver. In self-billing, the Seller is the sender and the Buyer is the receiver.
 
 [[senderparty]]
 == SenderParty
 
 The party that sends the Invoice Response.
-This may be the Buyer who received the invoice, or it may be a service provider processing the invoice on behalf of the Buyer.
-If the Invoice Response is issued by a service provider the name of the actual Buyer may be given with the invoice reference.
+This is the party that received the referenced invoice or credit note: the Buyer in standard billing and the Seller in self-billing.
+It may also be a service provider processing the document on behalf of that party.
+If the Invoice Response is issued by a service provider, the relevant Buyer and Seller may be given with the invoice reference.
 
 The information given for the sender is his EndpointID which is his Peppol Participant Identifier (PPID). The party identifier may be given as well and the schema that the identifier is based on.
 The name of the sender is then provided.
 
-Contact information for the sender (Buyer) is the person that the receiver (Seller) can contact when resolving an issue reported in the Invoice Response.
+Contact information for the sender identifies the person that the receiver can contact when resolving an issue reported in the Invoice Response.
 This should not be general company email and phone unless the sender has in place a process that would direct the contact efficiently to a relevant person.
 
 .UBL example:
@@ -41,8 +43,9 @@ This should not be general company email and phone unless the sender has in plac
 
 The party that sent the Invoice that the message is responding to.
 This is also the receiver of the Invoice Response.
-This may be the Seller who issued the invoice or a service provider who handles the invoicing process on behalf of the Seller.
-If this is a service provider, then the actual Seller may be identified as part of the invoice reference information.
+This is the Seller in standard billing and the Buyer in self-billing.
+It may also be a service provider who handles the invoicing process on behalf of that party.
+If this is a service provider, the relevant Buyer and Seller may be identified as part of the invoice reference information.
 
 .UBL example:
 [source, xml]
@@ -61,8 +64,8 @@ If this is a service provider, then the actual Seller may be identified as part 
 [[issuer-and-recipient-parties]]
 == Issuer and Recipient parties
 
-In the case when the Invoice processing is handled by a service provider on behalf or the Buyer or the Seller then the sending/receiving party is not the Buyer/Seller stated in the Invoice document.
-In those cases, it is required to identify the Buyer and the Seller as declared in the referenced Invoice.
+When Invoice processing is handled by a service provider on behalf of the Buyer or the Seller, the sending or receiving party is not the Buyer or Seller stated in the Invoice document.
+In those cases, it is required to identify the Buyer and the Seller as declared in the referenced Invoice. These commercial roles do not determine the direction of the Invoice Response.
 This shall be done by giving an identifier and a name.
 
 .UBL example:

--- a/guides/profiles/63-invoiceresponse/descriptions/response.adoc
+++ b/guides/profiles/63-invoiceresponse/descriptions/response.adoc
@@ -13,17 +13,17 @@ This information is given in the following hierarchy:
 Each Invoice Response may only reference one invoice and that invoice can only have one status at a time.
 If the status of that Invoice changes the respective change must be reported with another Invoice Response.
 
-The status clarification for the given status can be of either or both of two types - reason of that status and/or action expected by Seller.
-The purpose of this is to help Seller to understand the status and to resolve it in the correct way.
+The status clarification for the given status can be of either or both of two types - reason of that status and/or action expected from the issuer.
+The purpose of this is to help the issuer understand the status and resolve it in the correct way.
 
 As example if an invoice is rejected it will be represented as status code RE (Rejected) in the Invoice Response.
 For clarification, the Invoice Response would then state why it is rejected and there may be more than one reason.
-The clarification may further give the instructions regarding actions expected from the Seller, for example to cancel the Invoice with a Credit Note and issue a new corrective Invoice.
+The clarification may further give instructions regarding actions expected from the issuer, for example to cancel the Invoice with a Credit Note and issue a new corrective Invoice.
 
-To assist with resolution the Buyer might want to provide instructions on what is the correct data.
+To assist with resolution, the receiver might want to provide instructions on the correct data.
 
 
-.UBL example where TAX is VAT:
+.UBL standard billing example where TAX is VAT:
 [source, xml]
 ----
 <cac:DocumentResponse>

--- a/guides/profiles/63-invoiceresponse/principles/index.adoc
+++ b/guides/profiles/63-invoiceresponse/principles/index.adoc
@@ -3,10 +3,12 @@
 = Principles and prerequisites
 
 This chapter describes the principles and assumptions that underlie the use of the Peppol Invoice Response.
-The term Invoice in this specification is used for both an invoice and a credit note unless otherwise stated in the text or clear from the context.
+The term Invoice in this specification is used for an invoice, a self-billed invoice, and a credit note unless otherwise stated in the text or clear from the context.
 
 An Invoice Response can be used in the process of the exchange of invoices and credit notes until the parties have agreed on its settlement as paid or cancelled.
-It provides the Seller, as the issuer of the invoice or credit note, with information about the status of his invoice or credit note and provides the Buyer, as receiver of the invoice or credit note, with efficient means for keeping the Seller informed.
+It provides the issuer of the invoice or credit note with information about the status of the document and provides its receiver with efficient means for keeping the issuer informed.
+
+In standard billing, the Buyer receives the invoice and sends the Invoice Response to the Seller. In self-billing, the Seller receives the self-billed invoice and sends the Invoice Response to the Buyer.
 
 
 :leveloffset: +1

--- a/guides/profiles/63-invoiceresponse/principles/parties.adoc
+++ b/guides/profiles/63-invoiceresponse/principles/parties.adoc
@@ -26,15 +26,17 @@ Examples of customer roles: buyer, consignee, debtor, contracting body.
 
 |Seller
 |Role
-a|One who issues an invoice for items or services sold to a Buyer and to whom a debt is owed.
-The Party that claims the payment and is responsible for resolving billing issues and arranging settlement.
+a|One who supplies items or services to a Buyer and to whom a debt is owed.
+In standard billing, the Seller issues the invoice. In self-billing, the Buyer issues the self-billed invoice on behalf of the Seller.
+The Seller claims the payment and is responsible for resolving billing issues and arranging settlement.
 
 Also, known as Invoice Issuer, Accounts Receivable, Creditor, Economic operator.
 
 |Buyer
 |Role
-a|One who receives an invoice for items or services bought from a Seller and who owes debt.
-The Party responsible for making settlements relating to a purchase.
+a|One who buys items or services from a Seller and who owes debt.
+In standard billing, the Buyer receives the invoice. In self-billing, the Buyer issues the self-billed invoice to the Seller.
+The Buyer is responsible for making settlements relating to a purchase.
 
 Also, known as Invoicee, Accounts Payable, Debtor
 
@@ -52,17 +54,19 @@ image::images/roles.png[align="center"]
 Following paragraphs list the responsibilities and activities carried out by each party in the Invoice Response process from a technical, practical and informative perspective.
 Any legal implications of the measures discussed here are outside the scope of this document.
 
-=== Seller
+=== Issuer of the invoice or credit note
 
-* Not obliged to support the Invoice Response.
-* In case the Seller has registered support for the Invoice Response, then he is responsible for receiving an Invoice Response and to take actions in accordance to this specification.
+* Not obliged to support the Invoice Response unless required by the applicable profile or a bilateral agreement.
+* If the issuer has registered support for the Invoice Response, the issuer is responsible for receiving an Invoice Response and taking actions in accordance with this specification.
+* The issuer is the Seller in standard billing and the Buyer in self-billing.
 
-=== Buyer
+=== Receiver of the invoice or credit note
 
-* Not obliged to send an Invoice Response.
+* Not obliged to send an Invoice Response unless required by the applicable profile or a bilateral agreement.
 * Responsible for creating the Invoice Response.
 * Responsible for complying with the business rules used in invoice validations.
 * Responsible for when and how to use the Invoice Response in the frame of the Invoice Response document.
-* Responsible for expressing what action is expected from the Seller.
-* It is recommended that the Buyer maintains visibility of all Invoice Response messages created by him or on his behalf in order to solve potential issues with the Seller.
-* May have a bilateral agreement with Seller for using Invoice Response.
+* Responsible for expressing what action is expected from the issuer.
+* It is recommended that the receiver maintains visibility of all Invoice Response messages created by or on behalf of the receiver in order to solve potential issues with the issuer.
+* May have a bilateral agreement with the issuer for using Invoice Response.
+* The receiver is the Buyer in standard billing and the Seller in self-billing.

--- a/guides/profiles/63-invoiceresponse/principles/scope.adoc
+++ b/guides/profiles/63-invoiceresponse/principles/scope.adoc
@@ -1,28 +1,28 @@
 [[scope-of-invoice-response-message]]
 = Scope of Invoice Response
 
-Invoice Response is an invoice and credit note specific response message that can be used to inform the Seller of the status of an invoice in the Buyer's approval and payment processes, based on the Buyer’s business rules and/or a Seller/Buyer agreement.
+Invoice Response is an invoice and credit note specific response message that can be used by the receiver of an invoice or credit note to inform its issuer of the status of the document in the receiver's approval and processing workflow, based on the receiver's business rules and/or a Seller/Buyer agreement.
+
+In a standard billing process, the Buyer receives the invoice and sends the Invoice Response to the Seller. In a self-billing process, the Seller receives the self-billed invoice and sends the Invoice Response to the Buyer.
 
 .Invoice Response will provide following benefits to its users:
-* Invoice Response helps the Seller to initiate an action early in the case when processing of an invoice is challenged on the Buyer side.
-* The response informs Seller whether his invoice is in due process or whether that process is disrupted and requires action from Seller.
-* Invoice Response informs the Seller when their invoice has been approved or payment has been initiated so that the Seller can manage their cash flows and monitor the reception of funds through the payment channels.
-* Invoice Response provides automated means to the Buyer to keep the Seller informed of the invoice status in his invoice verification process and thus reduces or eliminates the need for manual status queries.
-* Invoice Response is designed to support automatic processing on the Seller side although it still may require manual actions.
-* Invoice Response is an informative message from Buyer to Seller.
-* Invoice Response structures the feedback loop from Buyer to Seller regarding the invoice handling process on Buyer’s side.
-* Invoice Response is an option for the Buyer to inform Seller about Buyer’s decisions in invoice processing in a structured or unstructured form.
+* Invoice Response helps the issuer initiate an action early when processing of an invoice or credit note is challenged by the receiver.
+* The response informs the issuer whether the document is being processed or whether that process is disrupted and requires action from the issuer.
+* Invoice Response provides automated means for the receiver to keep the issuer informed of the document status and thus reduces or eliminates the need for manual status queries.
+* Invoice Response is designed to support automatic processing on the issuer side although it still may require manual actions.
+* Invoice Response structures the feedback loop from the document receiver to the document issuer.
+* Invoice Response allows the document receiver to communicate decisions about document processing in a structured or unstructured form.
 
 == In scope
 
 .The following concepts are within the scope of the Invoice Response:
-* Buyer can inform Seller about Invoice and credit note processing steps and statuses on Buyer’s side.
-* Invoice Response is based on Buyer’s business rules.
-* Invoice Response is a one directional message only - from Buyer to Seller.
+* The receiver can inform the issuer about invoice and credit note processing steps and statuses in the receiver's workflow.
+* Invoice Response is based on the receiver's business rules.
+* Invoice Response is a one directional message from the receiver of the referenced business document to its issuer. This is Buyer to Seller for standard billing and Seller to Buyer for self-billing.
 * Several response messages can potentially be exchanged for one invoice or credit note.
-* Response content may require manual action on Seller’s side.
+* Response content may require manual action on the issuer's side.
 * Invoice Response supports only push message of the invoice status.
-* Invoice Response can not be automatically requested by Seller.
+* Invoice Response can not be automatically requested by the document issuer.
 * Acknowledging that a transmitted invoice has been received and can be processed.
 
 == Out of scope

--- a/guides/profiles/63-invoiceresponse/process/code-policy/clarification.adoc
+++ b/guides/profiles/63-invoiceresponse/process/code-policy/clarification.adoc
@@ -1,29 +1,29 @@
 [[clarification]]
 = Clarification
 
-Depending on the status code, a clarification may be needed to state the Buyer’s reason for the status and/or any expected action from the Seller’s side.
-The clarification may be given either as text (in Status Reason) or as code (in StatusReasonCode). The purpose of the clarification is to provide the Seller with structured information which enables him to partially or fully automate his processing.
+Depending on the status code, a clarification may be needed to state the receiver's reason for the status and/or any expected action from the issuer.
+The clarification may be given either as text (in Status Reason) or as code (in StatusReasonCode). The purpose of the clarification is to provide the issuer with structured information which enables the issuer to partially or fully automate its processing.
 The clarifications are of two types.
 
 * Reasons for the given status.
-* Actions that the Buyer requests from the Seller.
+* Actions that the receiver requests from the issuer.
 
 These two types of clarifications are contained in separate code lists that have different list identifiers.
-This allows the Seller to distinguish between the two types of clarifications.
+This allows the issuer to distinguish between the two types of clarifications.
 Clarification codes are defined in {link-codelist}.
 
-Similar business reason (for example missing order number) may trigger different statuses depending on the Buyer’s business process. (e.g. missing order number - some of the Buyers might ’Reject’ the invoice but some of the Buyers might put it ’Under query’).
+Similar business reasons (for example, a missing order number) may trigger different statuses depending on the receiver's business process.
 
 [[detail-type-codes-and-values]]
 == Detail type codes and values
 
-For each clarification code the Buyer can provide details to assist in the correction.
-For example, if an invoice contains the wrong Buyers TAX number then the Buyer can provide the correct number in the Invoice Response.
+For each clarification code the receiver can provide details to assist in the correction.
+For example, if an invoice contains the wrong Buyer's TAX number then the Buyer can provide the correct number in the Invoice Response.
 When a textual clarification that includes information about the correct values is not sufficient, but the correct values need to be provided in a structured way that information can be given by providing a type code that identifies the information type and the correct value.
 
-The detail type code for each data type shall be the business term identifier of the referenced document that shall be corrected, and the detail value shall be the value that the Buyer proposes as the correct one.
+The detail type code for each data type shall be the business term identifier of the referenced document that shall be corrected, and the detail value shall be the value that the receiver proposes as the correct one.
 
-Example:
+Standard billing example:
 
 A Buyer receives a Peppol invoice where the following is true
 

--- a/guides/profiles/63-invoiceresponse/process/code-policy/index.adoc
+++ b/guides/profiles/63-invoiceresponse/process/code-policy/index.adoc
@@ -2,8 +2,8 @@
 = Code Policy
 
 Key information in an Invoice Response is the reporting of the status of the invoice.
-The objective of the status code is to provide the Seller with a clear indication of the status of the referenced invoice inside the Buyers process in a way that allows the Seller to clearly identify if an action is required on his behalf.
-The status code can be supplemented with a clarification or an action code or textual note that explains the status and assists the Seller in deciding on correct reaction.
+The objective of the status code is to provide the issuer with a clear indication of the status of the referenced invoice inside the receiver's process in a way that allows the issuer to clearly identify if an action is required.
+The status code can be supplemented with a clarification, an action code, or a textual note that explains the status and assists the issuer in deciding on the correct reaction.
 
 The codes in the Invoice Response are given in the following structure.
 
@@ -17,7 +17,7 @@ Each Invoice Response must have one and only one status code.
 
 For each Invoice Response (status) there is the option of providing one or more clarification.
 
-For each clarification there is the option to provide data that the Buyer proposes as a correction.
+For each clarification there is the option to provide data that the receiver proposes as a correction.
 
 .Example
 ====

--- a/guides/profiles/63-invoiceresponse/process/code-policy/status-codes.adoc
+++ b/guides/profiles/63-invoiceresponse/process/code-policy/status-codes.adoc
@@ -4,14 +4,14 @@
 .The following policies apply to the use of status codes:
 * List of Status codes is fixed and can not be changed bilaterally.
 * There are seven pre-agreed status codes (main statuses).
-* Status code is sent from Buyer to Seller to inform the Seller about further processing of the invoice on Buyer side.
-* Status code does not inform the business reason for the Status to the Seller (there is a clarification code for that).
-* Every status can be the first status sent to the Seller but from there further statuses must follow a defined order (see <<invoice-response-process-rules>>, rule OP-BR111-R012).
-* Maximum time for first response 3 days – The Seller should receive the first Invoice Response within 3 working days.
-** By receiving the first Response message the Seller will know that an Invoice has been received by the Buyer and what its status is.
-** However, if the Seller does not receive any response he should wait 3 working days before contacting the Buyer to query whether the Invoice was received.
-** A Buyer who has received an invoice should therefore provide a first Response before that time to notify the Seller that it has been received and what its status is.
-* The minimum set of Statuses that must be supported by a Buyer is “Message acknowledged”, “Rejected” and “Approved”.
+* The status code is sent from the receiver of the invoice to its issuer to inform the issuer about further processing of the invoice on the receiver's side.
+* The status code does not inform the issuer of the business reason for the status (there is a clarification code for that).
+* Every status can be the first status sent to the issuer, but further statuses must follow a defined order (see <<invoice-response-process-rules>>, rule OP-BR111-R012).
+* Maximum time for first response is 3 days – The issuer should receive the first Invoice Response within 3 working days.
+** By receiving the first response message, the issuer will know that an Invoice has been received and what its status is.
+** If the issuer does not receive any response, it should wait 3 working days before contacting the receiver to query whether the Invoice was received.
+** A receiver should therefore provide a first response before that time to notify the issuer that the Invoice has been received and what its status is.
+* The minimum set of statuses that must be supported by a receiver is “Message acknowledged”, “Rejected” and “Approved”.
 
 
 .The columns in the below table shall be understood as follows:
@@ -25,19 +25,19 @@ UNECE definition:: The definition of the code, based on UNECE code list 4343.
 BIS usage:: An explanation of how the UNECE definition of the code shall be interpreted and applied in transactions that follow this BIS.
 
 Response expected::
-Indicates that the Buyer expects a response from the Seller in accordance to the information given in the Invoice Response.
-If no response is expected, then the Buyer will proceed with the processing of the invoice without interruption.
-If a response is expected, then the Buyer will not proceed with the processing until the Seller has provided the response (externally).
+Indicates that the document receiver expects a response from the issuer in accordance with the information given in the Invoice Response.
+If no response is expected, then the receiver will proceed with the processing of the invoice without interruption.
+If a response is expected, then the receiver will not proceed with the processing until the issuer has provided the response (externally).
 
-Clarification required:: Indicates that when Invoice Response contains this code then a clarification must be provided by the Buyer in the form of a Status Reason code (See {link-codelist}) or text or both.
+Clarification required:: Indicates that when an Invoice Response contains this code, a clarification must be provided by the document receiver in the form of a Status Reason code (See {link-codelist}), text, or both.
 
 Mandatory::
-Indicates that a Buyer who supports this BIS shall at minimum be able to report these statuses in the processing of the invoice.
-In other words, the Seller can at minimum expect to receive this status information.
+Indicates that a document receiver who supports this BIS shall at minimum be able to report these statuses in the processing of the invoice.
+In other words, the issuer can at minimum expect to receive this status information.
 
 Final::
 Indicates that this is a final status in the processing of the referenced invoice.
-The Seller will not receive any further Invoice Response messages referencing this invoice.
+The issuer will not receive any further Invoice Response messages referencing this invoice.
 
 .The Status codes used in an Invoice Response are defined in the below table and are a subset UNECE code list 4343 with additional codes.
 [cols="1h,1,3,3,1,1,1,1",options="header"]
@@ -50,24 +50,24 @@ The Seller will not receive any further Invoice Response messages referencing th
 |Clarification Required
 |Mandatory
 |Final
-|AB |Message acknowledgement |Indicates that an acknowledgement relating to receipt of message or transaction is required. |Status is used when Buyer has received a readable invoice message that can be understood and submitted for processing by the Buyer. |NO |NO |YES |NO
-|IP |In Process |Indicates that the referenced message or transaction is being processed. |Status is used when the processing of the Invoice has started in Buyers system. |NO |NO |NO |NO
-|UQ |Under query |Indicates that the processing of the referenced message has been halted pending response to a query. |Status is used when Buyer will not proceed to accept the Invoice without receiving additional information from the Seller. |YES |YES |NO |NO
-|CA |Conditionally accepted |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) has been accepted under conditions indicated in this message. |Status is used when Buyer is accepting the Invoice under conditions stated in ‘Status Reason’ and proceed to pay accordingly unless disputed by Seller. |NOfootnote:[When an invoice is conditionally accepted (CA) the Buyer will proceed with the processing according to the conditions it has stated.
-The Seller may still respond externally if he has comments or objections to the conditions given.] |YES |NO |NO
-|RE |Rejected |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) is not accepted. |Status is used only when the Buyer will not process the referenced Invoice any further. +
-Buyer is rejecting this invoice but not necessarily the commercial transaction.
+|AB |Message acknowledgement |Indicates that an acknowledgement relating to receipt of message or transaction is required. |Status is used when the receiver has received a readable invoice message that can be understood and submitted for processing. |NO |NO |YES |NO
+|IP |In Process |Indicates that the referenced message or transaction is being processed. |Status is used when processing of the Invoice has started in the receiver's system. |NO |NO |NO |NO
+|UQ |Under query |Indicates that the processing of the referenced message has been halted pending response to a query. |Status is used when the receiver will not proceed to accept the Invoice without receiving additional information from the issuer. |YES |YES |NO |NO
+|CA |Conditionally accepted |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) has been accepted under conditions indicated in this message. |Status is used when the receiver is accepting the Invoice under conditions stated in ‘Status Reason’ and will proceed accordingly unless disputed by the issuer. |NOfootnote:[When an invoice is conditionally accepted (CA), the receiver will proceed with processing according to the conditions it has stated.
+The issuer may still respond externally if it has comments or objections to the conditions given.] |YES |NO |NO
+|RE |Rejected |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) is not accepted. |Status is used only when the receiver will not process the referenced Invoice any further. +
+The receiver is rejecting this invoice but not necessarily the commercial transaction.
 Although it can be used also for rejection for commercial reasons (invoice not corresponding to delivery). |YES |YES |YES |YES
-|AP |Accepted |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) has been accepted. |Status is used only when the Buyer has given a final approval of the invoice and the next step is payment |NO |NO |YES |NO
-|PD with PPD (1) |Partially Paid |Indicates that the referenced document or transaction has been partially paid. |Status is used together with Clarification Reason code PPD, only when the Buyer has initiated the payment of the invoice without having paid the accepted amount in full. |NO |NO |NO |NO
-|PD |Fully Paid |Indicates that the referenced document or transaction has been paid. |Status is used only when the Buyer has initiated the payment of the invoice. |NO |NO |NO |YES
+|AP |Accepted |Indication that the referenced offer or transaction (e.g., cargo booking or quotation request) has been accepted. |Status is used only when the receiver has given final approval of the invoice. |NO |NO |YES |NO
+|PD with PPD (1) |Partially Paid |Indicates that the referenced document or transaction has been partially paid. |Status is used together with Clarification Reason code PPD, only when the sender is responsible for payment and has initiated payment without having paid the accepted amount in full. |NO |NO |NO |NO
+|PD |Fully Paid |Indicates that the referenced document or transaction has been paid. |Status is used only when the sender is responsible for payment and has initiated payment of the invoice. |NO |NO |NO |YES
 
 |====
 
 (1) Status code PD (Paid) together with Clarification Reason code PPD (Partially Paid) is the case when an invoice is partially paid with the intention of later paying the full invoice amount as was accepted.
 
-The sequence of the status codes is fixed to allow the Seller, as receiver of the Invoice Response, to advance the status of the invoice in his systems in an orderly way. See <<invoice-response-process-rules>>.
-This requires the Buyer to be conservative in reporting status and only advance an invoice when the status is reasonably certain.
+The sequence of the status codes is fixed to allow the issuer, as receiver of the Invoice Response, to advance the status of the invoice in its systems in an orderly way. See <<invoice-response-process-rules>>.
+This requires the document receiver to be conservative in reporting status and only advance an invoice when the status is reasonably certain.
 
 The status of an invoice must advance in the following sequence, but any status may be the first one used or may be omitted.
 
@@ -81,8 +81,8 @@ The status of an invoice must advance in the following sequence, but any status 
 
 .Examples of status advancement:
 ====
-1.  If an invoice is paid right after being received, the Buyer can report with a single Invoice Response using the code PD.
-2.  If an invoice has been put under query then following the response from the Seller, the Buyer may advance it to any of the following codes:
+1.  In standard billing, if an invoice is paid right after being received, the Buyer can report with a single Invoice Response using the code PD.
+2.  If an invoice has been put under query, then following the response from the issuer, the receiver may advance it to any of the following codes:
 [horizontal]
  CA:: conditionally accepted
  RE:: Rejected
@@ -91,7 +91,7 @@ The status of an invoice must advance in the following sequence, but any status 
 ====
 
 Deviations from this sequence must be handled manually between the trading parties.
-As example, if a Buyer has stated that an invoice has been accepted they can not later send an Invoice Response indicating that it is under query or rejected.
-This does however not prohibit the Buyer from changing his decision, but he must report that to the Seller by other means than by using an Invoice Response.
+For example, if a receiver has stated that an invoice has been accepted, it can not later send an Invoice Response indicating that it is under query or rejected.
+This does not prohibit the receiver from changing its decision, but it must report that to the issuer by other means than by using an Invoice Response.
 
 The fixed order simplifies the automation of the processing for the receiver of the Invoice Response.

--- a/guides/profiles/63-invoiceresponse/process/index.adoc
+++ b/guides/profiles/63-invoiceresponse/process/index.adoc
@@ -12,6 +12,8 @@ include::../../../shared/bpmn/bpmn-legend.adoc[]
 [[process-in-general]]
 == Process in general
 
+=== Standard billing
+
 The process starts when a Seller party is preparing an electronic invoice and then sends it to the Buyer.
 After the invoice has been validated and transported the Buyer party receives the invoice.
 
@@ -40,6 +42,12 @@ The Buyer may then notify the Seller that the payment has been initiated.
 
 .Common simplified invoice approval process
 image::images/IMR-bpmn.png[]
+
+=== Self-billing
+
+In a self-billing process, the Buyer issues a self-billed invoice on behalf of the Seller and sends it to the Seller. The Seller validates and processes the self-billed invoice and may use an Invoice Response to report its status to the Buyer.
+
+For this flow, the Seller sending the Invoice Response is represented as `cac:SenderParty` and the Buyer receiving it is represented as `cac:ReceiverParty`. The response describes the status inside the Seller's processing workflow. The same Invoice Response syntax, validation rules, status codes, and clarification codes apply; no separate self-billing response document type is used.
 
 :leveloffset: +1
 

--- a/guides/profiles/63-invoiceresponse/process/rules.adoc
+++ b/guides/profiles/63-invoiceresponse/process/rules.adoc
@@ -11,9 +11,9 @@ The Invoice Response process governs how and when the transactions are issued an
 
 |OP-BR111-R001
 a|
-The Invoice Response is one directional message only - from Buyer to Seller.
+The Invoice Response is a one directional message from the receiver of the referenced business document to its issuer.
 
-Invoice Response is meant to be sent from Buyer to Seller informing about invoice status inside the Buyer’s business process.
+For standard billing, the Buyer sends the Invoice Response to the Seller. For self-billing, the Seller sends the Invoice Response to the Buyer. The response informs the issuer about the document status inside the receiver's business process.
 
 |OP-BR111-R002
 |Each Invoice Response is intended to carry one status code (top level status) at a time, for an individual invoice.
@@ -25,19 +25,19 @@ An invoice can only have one status at each time.
 
 |OP-BR111-R004
 |If an invoice has been given the status Rejected or Paid, then no further Invoice Response may be sent regarding that invoice.
-I.e. Seller may ignore them.footnote:exept[Business situations that require exceptions to these rules are not prohibited by this BIS but are not supported by the Invoice Response described in it.
+I.e. the issuer may ignore them.footnote:exept[Business situations that require exceptions to these rules are not prohibited by this BIS but are not supported by the Invoice Response described in it.
 Such business situations must be handled externally between the trading parties.]
 
 |OP-BR111-R005
 |If an invoice has been given status Approved, then that may only be followed with an Invoice Response giving status Paid.
-I.e. Seller may ignore them.footnote:exept[]
+I.e. the issuer may ignore them.footnote:exept[]
 
 |OP-BR111-R006
-|A Buyer shall provide first Invoice Response within 3 working days.
+|The receiver of the invoice or credit note shall provide the first Invoice Response within 3 working days.
 
 |OP-BR111-R007
-|An Invoice Response doesn’t prescribe the invoice workflow process for the Buyer.
-Different Buyers may have different workflows processes for the invoices.
+|An Invoice Response doesn’t prescribe the invoice workflow process for the receiver.
+Different receivers may have different workflow processes for invoices.
 
 |OP-BR111-R008
 |An Invoice Response does not have any legal power.
@@ -73,7 +73,7 @@ PD:: Paid (Final status, The status code “Paid” will probably not be used in
 The process may start at any status and not all statuses must be reported.
 
 |OP-BR111-R013
-|Seller can dispute any status presented by Buyer in Invoice Response with an external process.
+|The issuer can dispute any status presented by the receiver in an Invoice Response with an external process.
 
 |OP-BR111-R014
 |Document type code must conform to the document type code of the original message the response is sent to (usually 380 for the commercial invoice and 381 for credit note).

--- a/guides/profiles/63-invoiceresponse/process/use-cases/index.adoc
+++ b/guides/profiles/63-invoiceresponse/process/use-cases/index.adoc
@@ -20,6 +20,7 @@ While the use cases are drawn up to illustrate the general functionality of this
 |<<uc6c,6c>>  |Invoice is in under query because of wrong details, partial credit note requested.
 |<<uc7,7>>  |Invoice payment has been initiated.
 |<<uc8,8>>  |Invoice is accepted by a third party acting on behalf of the Buyer.
+|<<uc9,9>>  |Self-billed invoice is rejected by the Seller.
 |====
 
 [NOTE]

--- a/guides/profiles/63-invoiceresponse/process/use-cases/use-cases.adoc
+++ b/guides/profiles/63-invoiceresponse/process/use-cases/use-cases.adoc
@@ -209,3 +209,16 @@ Service provider +
 Seller
 |Result |Seller is notified that an Invoice has been accepted and will be paid on due date.
 |====
+
+[[uc9]]
+.Use case 9 — Self-billed invoice is rejected by the Seller.
+[cols="1h,5",options="header"]
+|====
+|Use Case number |9
+|Use Case Name |Self-billed invoice is rejected by the Seller.
+|Assumption and description |The Buyer issued a self-billed invoice on behalf of the Seller. The Seller cannot accept the self-billed invoice because a reference is incorrect.
+|The flow |The Seller sends an Invoice Response with status 'Rejected' and a clarification to the Buyer. The Seller is represented as `cac:SenderParty`, the Buyer as `cac:ReceiverParty`, and the referenced self-billed invoice uses document type code `389`.
+|Parties involved |Seller +
+Buyer
+|Result |The Buyer is informed that the self-billed invoice was rejected and can resolve the issue with the Seller.
+|====

--- a/guides/profiles/63-invoiceresponse/requirements/process.adoc
+++ b/guides/profiles/63-invoiceresponse/requirements/process.adoc
@@ -11,27 +11,27 @@ These requirements may influence the data requirements in the transaction, but t
 |Requirement
 |br111-001
 |There is an agreed way to express when there will be no more Invoice Response's regarding a particular invoice.
-The definition of status of the Invoice (whether approved or rejected) should clearly state whether it is a final status after which there cannot be any further Invoice Response’s sent by the Buyer in relation to that Invoice.
+The definition of status of the Invoice (whether approved or rejected) should clearly state whether it is a final status after which the receiver cannot send any further Invoice Responses in relation to that Invoice.
 
 |br111-002
-|An Invoice Response is intended for automatic processing on the Seller side although it still might require some manual actions.
+|An Invoice Response is intended for automatic processing on the issuer side although it still might require some manual actions.
 Free text response is also an option inside the Invoice Response.
-Validation rules might be automatically or manually executed on the Buyer’s side.
-The Buyer might outsource the rule’s execution to a service provider.
+Validation rules might be automatically or manually executed on the receiver's side.
+The receiver might outsource the rule's execution to a service provider.
 
 |br111-003 |
-An Invoice Response should clearly inform the Seller of any additional actions they should execute so that the Buyer can continue the Invoice processing.
+An Invoice Response should clearly inform the issuer of any additional actions it should execute so that the receiver can continue the Invoice processing.
 
 |br111-004
-|An Invoice Response is an invoice specific message based on Buyer’s business rules and/or Seller/Buyer’s agreement.
+|An Invoice Response is an invoice-specific message based on the receiver's business rules and/or a Seller/Buyer agreement.
 
 |br111-005
-a|An Invoice Response is one directional message only - from Buyer to Seller.
+a|An Invoice Response is a one directional message from the receiver of the referenced business document to its issuer.
 
-Invoice Response is meant to inform the Seller about Invoice status inside the Buyer’s business process as well potential actions the Seller should take (if any).
+The direction is Buyer to Seller for standard billing and Seller to Buyer for self-billing. The response informs the issuer about the Invoice status inside the receiver's business process and any potential actions the issuer should take.
 
 |br111-006
-|An Invoice Response status code is unambiguous: when applicable, it must be used to clearly indicate the next expected action to be executed by the Seller (described in Table below).
+|An Invoice Response status code is unambiguous: when applicable, it must be used to clearly indicate the next expected action to be executed by the issuer (described in Table below).
 |====
 
 [[registering-the-invoice-response-receiving-capability]]
@@ -39,11 +39,11 @@ Invoice Response is meant to inform the Seller about Invoice status inside the B
 
 In order to use the Invoice Response in the {peppol} network the following steps need to be carried out:
 
-* Seller shall register the capability to receive Invoice Response BIS63A in its SMP.
-* Seller is seen as the interested party to find out if a Buyer is capable to send Invoice Response.
+* The issuer shall register the capability to receive Invoice Response BIS63A in its SMP. This is the Seller in standard billing and the Buyer in self-billing.
+* The issuer is seen as the interested party to find out if the document receiver is capable of sending an Invoice Response.
 ** Usually the exchange of Invoice Response is agreed by the business parties beforehand.
 
-IMPORTANT: However, if the Seller has registered the receiving capability in the SMP then the Buyer can send an Invoice Response without previous agreement.
+IMPORTANT: However, if the issuer has registered the receiving capability in the SMP, then the document receiver can send an Invoice Response without previous agreement.
 
-* It is strongly recommended that a Buyer that sends an Invoice Response does that for all received Invoices.
-Not doing so may create uncertainty for the Seller and therefore create unwanted processing for both the Buyer and Seller.
+* It is strongly recommended that a document receiver that sends an Invoice Response does so for all received Invoices.
+Not doing so may create uncertainty for the issuer and therefore create unwanted processing for both the Buyer and Seller.

--- a/guides/profiles/63-invoiceresponse/requirements/transaction.adoc
+++ b/guides/profiles/63-invoiceresponse/requirements/transaction.adoc
@@ -23,14 +23,14 @@ This controls how the data model, code lists and transaction rules are designed.
 |An Invoice Response SHALL identify a previously received invoice or credit note by referring to the document, including the document identifier, document issue date and the document type.
 
 |tbr111-007
-|An Invoice Response SHALL support coded expressions of status and clarifications in a way that supports automation of the message processing by the Seller.
+|An Invoice Response SHALL support coded expressions of status and clarifications in a way that supports automation of the message processing by the issuer.
 
 |tbr111-009
 |An Invoice Response SHALL support message exchange through the Peppol message transport network.
 
 |tbr111-010
-|An Invoice Response SHALL be able to clearly indicate the status of an invoice in the Buyers processing.
+|An Invoice Response SHALL be able to clearly indicate the status of an invoice in the receiver's processing.
 
 |tbr111-011
-|An Invoice Response should enable the Buyer to propose corrections in a structured way.
+|An Invoice Response should enable the receiver to propose corrections in a structured way.
 |====

--- a/guides/profiles/66-billing-with-response/introduction/index.adoc
+++ b/guides/profiles/66-billing-with-response/introduction/index.adoc
@@ -6,6 +6,8 @@ This BIS is a result of work within {openpeppol} and is published as part of the
 
 This BIS describes the business process for billing with a mandatory structured invoice response. It combines the Peppol BIS Billing and the Peppol BIS Invoice Response into a single collaboration profile.
 
-The sole distinction of this BIS is that the exchange of an invoice response is mandatory. Here, the Buyer is required to send at least one Invoice Response for each invoice or credit note received.
+The sole distinction of this BIS is that the exchange of an invoice response is mandatory. The receiver of an invoice or credit note is required to send at least one Invoice Response for each document received. This is the Buyer in standard billing and the Seller in self-billing.
+
+The existing Invoice Response transaction is used for both flows. In self-billing, the Seller sends the Invoice Response as `cac:SenderParty` and the Buyer receives it as `cac:ReceiverParty`. No separate response document type, syntax, or validation rules apply.
 
 All rules, constraints, code lists, and transaction requirements defined in both specifications apply fully and without modification. Implementers should refer to each respective BIS for the full set of requirements.

--- a/rules/examples/Invoice reponse use cases/T111-uc009-Self-billed invoice is rejected.xml
+++ b/rules/examples/Invoice reponse use cases/T111-uc009-Self-billed invoice is rejected.xml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+                Content:
+                This file contains a Peppol Invoice Response, profile 63.
+                It demonstrates Use Case 9 - Self-billed invoice is rejected by the Seller.
+
+                Errors:
+                None
+
+                Warnings:
+                None
+
+-->
+<ApplicationResponse xmlns="urn:oasis:names:specification:ubl:schema:xsd:ApplicationResponse-2"
+    xmlns:cac="urn:oasis:names:specification:ubl:schema:xsd:CommonAggregateComponents-2"
+    xmlns:cbc="urn:oasis:names:specification:ubl:schema:xsd:CommonBasicComponents-2"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+    <cbc:CustomizationID>urn:fdc:peppol.eu:poacc:trns:invoice_response:3</cbc:CustomizationID>
+    <cbc:ProfileID>urn:fdc:peppol.eu:poacc:bis:invoice_response:3</cbc:ProfileID>
+    <cbc:ID>imr-selfbilling-001</cbc:ID>
+    <cbc:IssueDate>2026-08-20</cbc:IssueDate>
+    <cac:SenderParty>
+        <cbc:EndpointID schemeID="0088">5798000012349</cbc:EndpointID>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Seller company</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:SenderParty>
+    <cac:ReceiverParty>
+        <cbc:EndpointID schemeID="0088">7330001000000</cbc:EndpointID>
+        <cac:PartyLegalEntity>
+            <cbc:RegistrationName>Buyer organization</cbc:RegistrationName>
+        </cac:PartyLegalEntity>
+    </cac:ReceiverParty>
+    <cac:DocumentResponse>
+        <cac:Response>
+            <cbc:ResponseCode>RE</cbc:ResponseCode>
+            <cac:Status>
+                <cbc:StatusReasonCode listID="OPStatusReason">REF</cbc:StatusReasonCode>
+                <cbc:StatusReason>The contract reference in the self-billed invoice is incorrect.</cbc:StatusReason>
+            </cac:Status>
+        </cac:Response>
+        <cac:DocumentReference>
+            <cbc:ID>SBI-2026-0042</cbc:ID>
+            <cbc:IssueDate>2026-08-19</cbc:IssueDate>
+            <cbc:DocumentTypeCode>389</cbc:DocumentTypeCode>
+        </cac:DocumentReference>
+    </cac:DocumentResponse>
+</ApplicationResponse>


### PR DESCRIPTION
Changed content of documentation to be more generic. Instead of buyer and seller, use sender and receiver.
Also added use case.
Do we need to update profile 66 as well? Billing-with-response
This is now part of the pull request but can be removed if not needed.