### PR TITLE
Poacc 933 incohrence between documentation and ubl xsd schematrons

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -22,8 +22,8 @@ if exist "%PROJECT%\target" (
 docker run --rm -i -v "%PROJECT%:/src" -v "%PROJECT%\target:/target" difi/vefa-structure:0.6.1
 
 :: Inferred mandatory cardinality, excluding asserts already covered by generated Txx-basic.sch
-powershell -NoProfile -ExecutionPolicy Bypass -File "%PROJECT%\tools\audit-inferred-mandatory-cardinality.ps1"
-if errorlevel 1 exit /b %ERRORLEVEL%
+:: powershell -NoProfile -ExecutionPolicy Bypass -File "%PROJECT%\tools\audit-inferred-mandatory-cardinality.ps1"
+:: if errorlevel 1 exit /b %ERRORLEVEL%
 
 :: Testing validation rules
 docker run --rm -i -v "%PROJECT%:/src" phelger/vefa-validator:2.4.3 build -x -t -n eu.peppol.poacc.upgrade.v3 -a rules -target target/validator-test /src

--- a/build.bat
+++ b/build.bat
@@ -21,6 +21,10 @@ if exist "%PROJECT%\target" (
 :: Structure
 docker run --rm -i -v "%PROJECT%:/src" -v "%PROJECT%\target:/target" difi/vefa-structure:0.6.1
 
+:: Inferred mandatory cardinality, excluding asserts already covered by generated Txx-basic.sch
+powershell -NoProfile -ExecutionPolicy Bypass -File "%PROJECT%\tools\audit-inferred-mandatory-cardinality.ps1"
+if errorlevel 1 exit /b %ERRORLEVEL%
+
 :: Testing validation rules
 docker run --rm -i -v "%PROJECT%:/src" phelger/vefa-validator:2.4.3 build -x -t -n eu.peppol.poacc.upgrade.v3 -a rules -target target/validator-test /src
 
@@ -61,5 +65,5 @@ docker run --rm -i -v "%PROJECT%:/documents" -v "%PROJECT%\target:/target" difi/
 exit /b %ERRORLEVEL%
 
 :report
-powershell -NoProfile -Command "$matches = Select-String -LiteralPath '%~1' -Pattern '(?i)(?:^|\|-|\[)(?:WARN(?:ING)?|ERROR)(?=\s|:|\]|$)'; if ($matches) { Write-Host ''; Write-Host 'Warnings and errors from %~1:'; foreach ($match in $matches) { '{0}: {1}' -f $match.LineNumber, $match.Line } } else { Write-Host ''; Write-Host 'Warnings and errors from %~1: None.' }; $testSummary = @(Select-String -LiteralPath '%~1' -Pattern '(?i)tests performed'); Write-Host ''; Write-Host 'Build log from the last tests performed line:'; if ($testSummary.Count -gt 0) { Get-Content -LiteralPath '%~1' | Select-Object -Skip ($testSummary[$testSummary.Count - 1].LineNumber - 1) } else { Write-Host 'No test summary found.' }"
+powershell -NoProfile -Command "$matches = Select-String -LiteralPath '%~1' -Pattern '(\d{2}:\d{2}:\d{2}(?:[.,]\d{1,3})?\s+(?:\|\s*-?)?(?:WARN(?:ING)?|ERROR).+)'; if ($matches) { Write-Host ''; Write-Host 'Warnings and errors from %~1:'; foreach ($match in $matches) { '{0}: {1}' -f $match.LineNumber, $match.Matches[0].Groups[1].Value } } else { Write-Host ''; Write-Host 'Warnings and errors from %~1: None.' }; $testSummary = @(Select-String -LiteralPath '%~1' -Pattern '(?i)tests performed'); Write-Host ''; Write-Host 'Build log from the last tests performed line:'; if ($testSummary.Count -gt 0) { Get-Content -LiteralPath '%~1' | Select-Object -Skip ($testSummary[$testSummary.Count - 1].LineNumber - 1) } else { Write-Host 'No test summary found.' }"
 goto :eof

--- a/build.log
+++ b/build.log
@@ -1,0 +1,4471 @@
+13:50:42 INFO  n.d.vefa.structure.Runner - Loading project resources.
+13:50:42 INFO  n.d.vefa.structure.Runner - Step 'LOAD'.
+13:50:42 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:43 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:44 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.ResourceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'PRE_REFERENCES'.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'REFERENCES'.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.CounterProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.LinkingCodeListsProcessor.
+13:50:45 WARN  n.d.v.s.p.LinkingCodeListsProcessor - Unknown code list '2'.
+13:50:45 WARN  n.d.v.s.p.LinkingCodeListsProcessor - Code list 'UNCL5305' is not referenced in structure(s).
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.LinkingNamespaceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.processor.LinkingRulesProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'POST_REFERENCES'.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.ext.namespaces.NamespaceProcessor.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'VALIDATION'.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'PRE_ARTIFACTS'.
+13:50:45 INFO  n.d.vefa.structure.Runner - Step 'ARTIFACTS'.
+13:50:45 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.ext.schematrongen.SchematronProcessor.
+13:50:46 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.ext.asciidoctor.AdocProcessor.
+13:50:46 INFO  n.d.vefa.structure.Runner - Step 'POST_ARTIFACTS'.
+13:50:46 INFO  n.d.vefa.structure.Runner - Step 'PUBLISH'.
+13:50:46 INFO  n.d.vefa.structure.Runner - no.difi.vefa.structure.ext.site.SiteProcessor.
+13:51:35 INFO  n.d.vefa.structure.Runner - Finished.
+13:51:36,586 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found logback-core version 1.5.32
+13:51:36,589 |-INFO in ch.qos.logback.classic.util.ContextInitializer@5af97850 - No custom configurators were discovered as a service.
+13:51:36,590 |-INFO in ch.qos.logback.classic.util.ContextInitializer@5af97850 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
+13:51:36,592 |-INFO in ch.qos.logback.classic.util.ContextInitializer@5af97850 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
+13:51:36,605 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
+13:51:36,614 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/vefa-validator/conf/logback.xml]
+13:51:36,615 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@5ef60048 - Resource [logback.xml] occurs multiple times on the classpath.
+13:51:36,615 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@5ef60048 - Resource [logback.xml] occurs at [jar:file:/vefa-validator/lib/validator-dist-2.4.3.jar!/logback.xml]
+13:51:36,615 |-WARN in ch.qos.logback.classic.util.DefaultJoranConfigurator@5ef60048 - Resource [logback.xml] occurs at [file:/vefa-validator/conf/logback.xml]
+13:51:36,817 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Scan attribute set to false.
+13:51:36,821 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [STDOUT]
+13:51:36,821 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
+13:51:36,833 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
+13:51:36,908 |-INFO in ch.qos.logback.core.ConsoleAppender[STDOUT] - NOTE: Writing to the console can be slow. Try to avoid logging to the 
+13:51:36,908 |-INFO in ch.qos.logback.core.ConsoleAppender[STDOUT] - console in production environments, especially in high volume systems.
+13:51:36,908 |-INFO in ch.qos.logback.core.ConsoleAppender[STDOUT] - See also https://logback.qos.ch/codes.html#slowConsole
+13:51:36,909 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [no.difi.vefa] to INFO
+13:51:36,909 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [no.difi.vefa.validator.util.SaxonErrorListener] to WARN
+13:51:36,910 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to INFO
+13:51:36,910 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [STDOUT] to Logger[ROOT]
+13:51:36,911 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@1d548a08 - End of configuration.
+13:51:36,912 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@16aa0a0a - Registering current configuration as safe fallback point
+13:51:36,922 |-INFO in ch.qos.logback.classic.util.ContextInitializer@5af97850 - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 320 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY
+
+13:51:37 INFO  BuildTask - Source '/src/rules'
+13:51:38 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T01.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T01.xsl'
+13:51:41 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T16.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T16.xsl'
+13:51:42 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T19.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T19.xsl'
+13:51:42 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T58.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T58.xsl'
+13:51:43 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T76.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T76.xsl'
+13:51:43 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T77.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T77.xsl'
+13:51:43 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T110.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T110.xsl'
+13:51:44 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T111.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T111.xsl'
+13:51:44 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T71.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T71.xsl'
+13:51:44 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T114.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T114.xsl'
+13:51:45 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T115.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T115.xsl'
+13:51:45 INFO  SchematronPreparer - Converting Schematron '/src/rules/sch/PEPPOLBIS-T116.sch' to XSLT '/src/target/validator-test/contents/xsl/PEPPOLBIS-T116.xsl'
+13:51:45 INFO  BuildTask - Loading '/src/rules/buildconfig.xml'
+13:51:46 INFO  PBCProvider - Just added the BouncyCastleProvider to the list of Security providers
+13:51:47 INFO  SchematronCheckerFactory - Compiling Schematron Compiler XSLT
+13:51:47 INFO  DirectorySourceInstance - Directory: /src/target/validator-test
+13:51:47 INFO  DirectorySourceInstance - Loading: /src/target/validator-test/eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice
+13:51:47 INFO  ValidatorEngine - Loading configurations from 'config-eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.xml'
+13:51:47 INFO  ValidatorEngine -   Loaded 'PEPPOL BIS Upgrade 3.0' and 'http://docs.peppol.eu/poacc/upgrade/3.0/'
+13:51:47 INFO  ValidationInstance - Loading document from stream
+13:51:47 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:47 INFO  ValidationInstance - Loading document from stream
+13:51:48 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:48 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: AdditionalItemProperty MUST contain exactly one Value.
+13:51:48 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:48 INFO  SchematronXsltChecker - Compiling SVRL Parser
+13:51:48 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:48 INFO  ValidationInstance - Loading document from stream
+13:51:48 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:48 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: AdditionalItemProperty MUST contain exactly one Value.
+13:51:48 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:48 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:48 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-INFERRED-CARDINALITY-T19.xml'
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 1) Verify period end date is later than or equal to start date
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 2) Verify period end date is later than or equal to start date
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 3) Verify period end date is later than or equal to start date
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 4) Verify period end date is later than or equal to start date
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 5) Verify period end date is later than or equal to start date
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R001.xml'
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 1) Verify Catalogue supplier name or identifier is specified
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 2) Verify Catalogue supplier name or identifier is specified
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:49 INFO  ValidationInstance -   Detected expectation: 3) Verify Catalogue supplier name or identifier is specified
+13:51:49 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:49 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:49 INFO  ValidationInstance - Loading document from stream
+13:51:49 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 4) Verify Catalogue supplier name or identifier is specified
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R004.xml'
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 1) Verify Catalogue customer name or identifier is specified
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 2) Verify Catalogue customer name or identifier is specified
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 3) Verify Catalogue customer name or identifier is specified
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 4) Verify Catalogue customer name or identifier is specified
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R005.xml'
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 1) Verify PriceAmount is not negative
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 2) Verify PriceAmount is not negative
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 3) Verify PriceAmount is not negative
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R006.xml'
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 1) Verify line validity period is within document validity period
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 2) Verify line validity period is within document validity period
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 3) Verify line validity period is within document validity period
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 4) Verify line validity period is within document validity period
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:50 INFO  ValidationInstance - Loading document from stream
+13:51:50 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:50 INFO  ValidationInstance -   Detected expectation: 5) Verify line validity period is within document validity period
+13:51:50 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:50 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 6) Verify line validity period is within document validity period
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R007.xml'
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 1) Verify maximum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 2) Verify maximum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 3) Verify maximum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R008.xml'
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 1) Verify minimum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 2) Verify minimum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 3) Verify minimum quantity greater than zero
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R009.xml'
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 1) Verify maximum quantity greater than or equal to minimum quantity
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 2) Verify maximum quantity greater than or equal to minimum quantity
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 3) Verify maximum quantity greater than or equal to minimum quantity
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 4) Verify maximum quantity greater than or equal to minimum quantity
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:51 INFO  ValidationInstance -   Detected expectation: 5) Verify maximum quantity greater than or equal to minimum quantity
+13:51:51 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:51 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:51 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R010.xml'
+13:51:51 INFO  ValidationInstance - Loading document from stream
+13:51:51 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 1) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 2) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 3) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 4) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 5) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 6) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 7) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 8) Verify pricde validity period is within line validity period
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R011.xml'
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 1) Verify that either seller item identification or standard item identification is specified
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 2) Verify that either seller item identification or standard item identification is specified
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 3) Verify that either seller item identification or standard item identification is specified
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R012.xml'
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 1) Verify line period end date is later than or equal to start date
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 2) Verify line period end date is later than or equal to start date
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 3) Verify line period end date is later than or equal to start date
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 4) Verify line period end date is later than or equal to start date
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:52 INFO  ValidationInstance -   Detected expectation: 5) Verify line period end date is later than or equal to start date
+13:51:52 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:52 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:52 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R013.xml'
+13:51:52 INFO  ValidationInstance - Loading document from stream
+13:51:52 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 1) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 2) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 3) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R014.xml'
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 3) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R015.xml'
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 1) Verify line period end date is later than or equal to start date
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 2) Verify line period end date is later than or equal to start date
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 3) Verify line period end date is later than or equal to start date
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 4) Verify line period end date is later than or equal to start date
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 5) Verify line period end date is later than or equal to start date
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R016.xml'
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 1) Verify that ProfileID is correct
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 2) Verify that ProfileID is correct
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: 3) Verify that ProfileID is correct
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  Tester - TestSet '/src/rules/unit-catalogue/PEPPOL-T19-R017.xml'
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:53 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: DocumentResponse MUST contain exactly one DocumentReference.
+13:51:53 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T58.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:53 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:53 INFO  ValidationInstance - Loading document from stream
+13:51:53 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: DocumentResponse MUST contain exactly one DocumentReference.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T58.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  Tester - TestSet '/src/rules/unit-catalogue-response/PEPPOL-INFERRED-CARDINALITY-T58.xml'
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 1) null
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 2) null
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R040.xml'
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 1) Verify validation of Norwegian organization number.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 2) Verify validation of Norwegian organization number.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 3) Verify validation of Norwegian organization number.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 4) Verify validation of Norwegian organization number.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R041.xml'
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 1) Invalid Danish organization number (CVR) provided.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 2) Invalid Danish organization number (CVR) provided.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R042.xml'
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 1) Invalid Beligan organization number (0208) provided.
+13:51:54 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:54 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:54 INFO  ValidationInstance - Loading document from stream
+13:51:54 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:54 INFO  ValidationInstance -   Detected expectation: 2) Invalid Beligan organization number (0208) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R043.xml'
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 1) ICD (0201) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 2) ICD (0201) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 3) ICD (0201) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R044.xml'
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 1) ICD (0210) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 2) ICD (0210) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 3) ICD (0210) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 4) ICD (0210) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R045.xml'
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 1) ICD (9907) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 2) ICD (9907) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R046.xml'
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 1) ICD (0211) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 2) ICD (0211) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 3) ICD (0211) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R047.xml'
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 1) ICD (0007) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 2) ICD (0007) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:55 INFO  ValidationInstance -   Detected expectation: 3) ICD (0007) provided.
+13:51:55 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:55 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:55 INFO  ValidationInstance - Loading document from stream
+13:51:55 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 4) ICD (0007) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R049.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 1) ICD (0151) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 2) ICD (0151) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 3) ICD (0151) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R050.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 1) Invalid Danish chamber of commerce number provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 2) Invalid Danish chamber of commerce number provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R052.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 1) Invalid Danish ERSTORG number (SE) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 2) Invalid Danish ERSTORG number (SE) provided.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R053.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 1) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 2) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 3) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 4) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 5) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: 6) Luxembourg Register of Legal Persons number (Matricule, schemeID 0240) MUST be exactly 11 digits, digits 5-6 must be a valid legal form type code (20-99), and digit 11 must be a valid mod-11 check digit.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-common/PEPPOL-COMMON-R059.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:56 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:51:56 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:56 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:56 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-INFERRED-CARDINALITY-T16.xml'
+13:51:56 INFO  ValidationInstance - Loading document from stream
+13:51:56 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify each item in a Despatch Advice line is identifiable by either “item sellers identifier” or “item standard identifier”
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify each item in a Despatch Advice line is identifiable by either “item sellers identifier” or “item standard identifier”
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 3) Verify each item in a Despatch Advice line is identifiable by either “item sellers identifier” or “item standard identifier”
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 4) Verify each item in a Despatch Advice line is identifiable by either “item sellers identifier” or “item standard identifier”
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 5) Verify each item in a Despatch Advice line is identifiable by either “item sellers identifier” or “item standard identifier”
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R003.xml'
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify each line has a name
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify each line has a name
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R004.xml'
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify each line has a delivered quantity
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify each line has a delivered quantity
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R005.xml'
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify each delivered quantity is not negative
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify each delivered quantity is not negative
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 3) Verify each delivered quantity is not negative
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R006.xml'
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify outstanding quantity reason is provided if the document contains an
+			outstanding quantity
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify outstanding quantity reason is provided if the document contains an
+			outstanding quantity
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 3) Verify outstanding quantity reason is provided if the document contains an
+			outstanding quantity
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R007.xml'
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 1) Verify DespatchAdvice supplier name or identifier is specified
+13:51:57 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:57 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:57 INFO  ValidationInstance - Loading document from stream
+13:51:57 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:57 INFO  ValidationInstance -   Detected expectation: 2) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 3) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 4) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R008.xml'
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 1) Verify Despatch advice buyer name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 2) Verify Despatch advice buyer name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 3) Verify Despatch advice buyer name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 4) Verify Despatch advice buyer name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R009.xml'
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 1) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 2) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 3) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 4) Verify DespatchAdvice supplier name or identifier is specified
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  Tester - TestSet '/src/rules/unit-despatch-advice/PEPPOL-T16-R010.xml'
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: ApplicationResponse MUST contain exactly one DocumentResponse.
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: ApplicationResponse MUST contain exactly one DocumentResponse.
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  Tester - TestSet '/src/rules/unit-invoice-response/PEPPOL-INFERRED-CARDINALITY-T111.xml'
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 1) Verify that status codes CU, UQ and RE must have a reason code
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 2) Verify that status codes CU, UQ and RE must have a reason code
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 3) Verify that status codes CU, UQ and RE must have a reason code
+13:51:58 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:58 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:58 INFO  ValidationInstance - Loading document from stream
+13:51:58 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:58 INFO  ValidationInstance -   Detected expectation: 4) Verify that status codes CU, UQ and RE must have a reason code
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 5) Verify that status codes CU, UQ and RE must have a reason code
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 6) Verify that status codes CU, UQ and RE must have a reason code
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-invoice-response/PEPPOL-T111-R001.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 1) Verify that clarification code OTH has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 2) Verify that clarification code OTH has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 3) Verify that clarification code OTH has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 4) Verify that clarification code OTH has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-invoice-response/PEPPOL-T111-R002.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 1) Verify that clarification code PPD has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 2) Verify that clarification code PPD has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 3) Verify that clarification code PPD has a description
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-invoice-response/PEPPOL-T111-R004.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: ApplicationResponse MUST contain exactly one DocumentResponse.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: ApplicationResponse MUST contain exactly one DocumentResponse.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-mlr/PEPPOL-INFERRED-CARDINALITY-T71.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: AccountingCustomerParty MUST contain exactly one Party.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: AccountingCustomerParty MUST contain exactly one Party.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-INFERRED-CARDINALITY-T01.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 1) Correct use of allowance codes.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 2) Correct use of allowance codes.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-CL001.xml'
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:51:59 INFO  ValidationInstance -   Detected expectation: 1) Correct use of charge codes.
+13:51:59 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:51:59 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:51:59 INFO  ValidationInstance - Loading document from stream
+13:51:59 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Correct use of charge codes.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-CL002.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 1) Verify line identifier is unique within the order
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Verify line identifier is unique within the order
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 3) Verify line identifier is unique within the order
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R001.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 1) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 3) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 4) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 5) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R003.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 1) Verify that line quantity is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Verify that line quantity is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 3) Verify that line quantity is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R004.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 1) Verify that price amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Verify that price amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 3) Verify that price amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R005.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected payable amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected payable amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:00 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected payable amount is not negative
+13:52:00 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:00 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:00 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R006.xml'
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:00 INFO  ValidationInstance - Loading document from stream
+13:52:00 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected total sum of line amounts is not negative
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected total sum of line amounts is not negative
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected total sum of line amounts is not negative
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R007.xml'
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 1) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 2) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 3) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 4) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 5) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 6) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 7) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 8) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 9) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R008.xml'
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:01 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R009.xml'
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:01 INFO  ValidationInstance - Loading document from stream
+13:52:01 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:01 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:01 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:01 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R010.xml'
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 5) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R011.xml'
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 1) Verify that each order line SHOULD have an ordered quantity
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 2) Verify that each order line SHOULD have an ordered quantity
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R013.xml'
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 1) Verify Order originatro name or identifier is specified
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 2) Verify Order originatro name or identifier is specified
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 3) Verify Order originatro name or identifier is specified
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 4) Verify Order originatro name or identifier is specified
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R014.xml'
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 1) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 2) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 3) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 4) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:02 INFO  ValidationInstance -   Detected expectation: 5) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:02 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:02 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:02 INFO  ValidationInstance - Loading document from stream
+13:52:02 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 6) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R016.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 4) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 5) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 6) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R017.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 1) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R019.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R020.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R021.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 5) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 6) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R022.xml'
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 1) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 2) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 3) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:03 INFO  ValidationInstance - Loading document from stream
+13:52:03 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:03 INFO  ValidationInstance -   Detected expectation: 4) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:03 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:03 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 5) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 6) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R023.xml'
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 1) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 2) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 3) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 4) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 5) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 6) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 7) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 8) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 9) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R024.xml'
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 1) Verify that base quantity is be a positive number above zero.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 2) Verify that base quantity is be a positive number above zero.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 3) Verify that base quantity is be a positive number above zero.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 4) Verify that base quantity is be a positive number above zero.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R025.xml'
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 1) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified. 
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 2) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified. 
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:04 INFO  ValidationInstance -   Detected expectation: 3) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified. 
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:04 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:04 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:04 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R026.xml'
+13:52:04 INFO  ValidationInstance - Loading document from stream
+13:52:04 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that item gross price is not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that item gross price is not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 3) Verify that item gross price is not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R027.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that all elements with datatype amount has maximum 2 decimals
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that all elements with datatype amount has maximum 2 decimals
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R028.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that all TaxCategories have a VAT rate, except if the order is not
+			subject to VAT.
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that all TaxCategories have a VAT rate, except if the order is not
+			subject to VAT.
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 3) Verify that all TaxCategories have a VAT rate, except if the order is not
+			subject to VAT.
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R029.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 3) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R030.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that ProfileID is correct
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that ProfileID is correct
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 3) Verify that ProfileID is correct
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R031.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance amounts are not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance amounts are not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:05 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance amounts are not negative
+13:52:05 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:05 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:05 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R032.xml'
+13:52:05 INFO  ValidationInstance - Loading document from stream
+13:52:05 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 1) Verify that any allowance charge amounts are not negative
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 2) Verify that any allowance charge amounts are not negative
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 3) Verify that any allowance charge amounts are not negative
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order/PEPPOL-T01-R033.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-INFERRED-CARDINALITY-T110.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 1) Correct use of allowance codes.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 2) Correct use of allowance codes.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T01-CL001.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 1) Correct use of charge codes.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 2) Correct use of charge codes.
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T01-CL002.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 1) Verify prices of items are not negative
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 2) Verify prices of items are not negative
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R001.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 1) Verify all items include either “item sellers identifier” or “item standard identifier”
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 2) Verify all items include either “item sellers identifier” or “item standard identifier”
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 3) Verify all items include either “item sellers identifier” or “item standard identifier”
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:06 INFO  ValidationInstance -   Detected expectation: 4) Verify all items include either “item sellers identifier” or “item standard identifier”
+13:52:06 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:06 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:06 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R002.xml'
+13:52:06 INFO  ValidationInstance - Loading document from stream
+13:52:06 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 1) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 2) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 3) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 4) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 5) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 6) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 7) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 8) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 9) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 10) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 11) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 12) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 13) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 14) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 15) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 16) All amounts have the same currency code as document currency
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R004.xml'
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 1) No error when payable amount is available and positive.
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 2) No error when payable amount is available and zero.
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 3) No error when payable amount is not available.
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 4) Trigger error when payable amount is available and negative.
+13:52:07 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:07 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:07 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R005.xml'
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:07 INFO  ValidationInstance - Loading document from stream
+13:52:07 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:07 INFO  ValidationInstance -   Detected expectation: 1) No error when line extension amount is available and positive.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 2) No error when line extension amount is available and zero.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 3) No error when line extension amount is not available.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 4) Trigger error when line extension amount is available and negative.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R006.xml'
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 1) No error when line extension amount is total of order line extensions.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 2) Trigger error when line extension amount is not total of order line extensions.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 3) Trigger no error when line extension amount not available.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R007.xml'
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 1) Valid example of document level charge.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 2) Invalid example of document level charge.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 3) Valid example of document level charge without total.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R008.xml'
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 1) Valid example of document level allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 2) Invalid example of document level allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 3) Valid example of document level allowance without total.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R009.xml'
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 1) Valid example with charge and allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 2) Valid example with charge and allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 3) Invalid example with charge and allowance with invalid charge.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 4) Invalid example with charge and allowance with invalid allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 5) Valid example without charge and allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 6) Invalid example without charge and allowance.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 7) Valid example with charge.
+13:52:08 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:08 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:08 INFO  ValidationInstance - Loading document from stream
+13:52:08 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:08 INFO  ValidationInstance -   Detected expectation: 8) Invalid example with charge.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 9) Valid example with allowance.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 10) Invalid example with allowance.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 11) Valid example without tax exclusive amount.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R010.xml'
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 1) Valid example with tax amount.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 2) Invalid example with tax amount.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 3) Valid example without tax amount.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 4) Invalid example without tax amount.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R011.xml'
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 1) Valid example with no prepaid amount or rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 2) Valid example with prepaid amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 3) Valid example with rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 4) Valid example with prepaid and rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 5) Invalid example with no prepaid amount or rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 6) Invalid example with prepaid amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 7) Invalid example with rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 8) Invalid example with prepaid and rounding amount
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R012.xml'
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 1) Verify Allowance/Charge amounts are not negative.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 2) Verify Allowance/Charge amounts are not negative.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 3) Verify Allowance/Charge amounts are not negative.
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R013.xml'
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance amounts are not negative
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance amounts are not negative
+13:52:09 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:09 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:09 INFO  ValidationInstance - Loading document from stream
+13:52:09 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:09 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance amounts are not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R021.xml'
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 1) Verify that item gross price is not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 2) Verify that item gross price is not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 3) Verify that item gross price is not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R022.xml'
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 1) Verify that any allowance charge amounts are not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 2) Verify that any allowance charge amounts are not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 3) Verify that any allowance charge amounts are not negative
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R023.xml'
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 3) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 4) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 5) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 6) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 7) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 8) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 9) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 10) Verify that VAT category tax amount = VAT category taxable amount x (VAT category rate / 100), rounded "half up" to two decimals.
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R024.xml'
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 1) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:10 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:10 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:10 INFO  ValidationInstance - Loading document from stream
+13:52:10 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:10 INFO  ValidationInstance -   Detected expectation: 2) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 3) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 4) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 5) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 6) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 7) Verify that OrderResponse total VAT amount = Σ VAT category tax amount
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R025.xml'
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 1) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 2) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 3) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 4) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 5) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 6) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 7) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 8) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 9) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R026.xml'
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 1) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 2) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 3) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 4) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 5) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:11 INFO  ValidationInstance - Loading document from stream
+13:52:11 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:11 INFO  ValidationInstance -   Detected expectation: 6) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:11 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:11 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 7) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 8) Verify that taxable category is the same in VAT breakdown as in line or allowance/charge
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R027.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT Breakdown with VAT Category code S, Z, IG, IP shall not have a VAT Exemption reason text, and codes E, AE, IC, G or O must have a VAT Exemption reason text 
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT Breakdown with VAT Category code S, Z, IG, IP shall not have a VAT Exemption reason text, and codes E, AE, IC, G or O must have a VAT Exemption reason text 
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R028.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT Breakdown with VAT Category code S, Z, IG, IP shall not have a VAT Exemption reason text, and codes E, AE, IC, G or O must have a VAT Exemption reason text 
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT Breakdown with VAT Category code S, Z, IG, IP shall not have a VAT Exemption reason text, and codes E, AE, IC, G or O must have a VAT Exemption reason text 
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-agreement/PEPPOL-T110-R029.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-INFERRED-CARDINALITY-T76.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 1) Verify that the buyer party official name or a buyer party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 2) Verify that the buyer party official name or a buyer party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 3) Verify that the buyer party official name or a buyer party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 4) Verify that the buyer party official name or a buyer party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 5) Verify that the buyer party official name or a buyer party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R001.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 1) Verify that the seller party official name or a seller party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 2) Verify that the seller party official name or a seller party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 3) Verify that the seller party official name or a seller party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 4) Verify that the seller party official name or a seller party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:12 INFO  ValidationInstance -   Detected expectation: 5) Verify that the seller party official name or a seller party identifier
+13:52:12 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:12 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:12 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R002.xml'
+13:52:12 INFO  ValidationInstance - Loading document from stream
+13:52:12 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) Verify line identifier is unique within the order response
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) Verify line identifier is unique within the order response
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 3) Verify line identifier is unique within the order response
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R003.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 3) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 4) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R004.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R005.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 3) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R007.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) An order response with code AP (Accepted) must NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) An order response with code AP (Accepted) must NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R008.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) An order response with code RE (Rejected) should NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) An order response with code RE (Rejected) should NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R009.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 1) An order response with code AB (Acknowledged) must NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: 2) An order response with code AB (Acknowledged) must NOT provide order lines.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:13 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:13 INFO  Tester - TestSet '/src/rules/unit-order-response/PEPPOL-T76-R010.xml'
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:13 INFO  ValidationInstance - Loading document from stream
+13:52:13 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:13 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: AdditionalItemProperty MUST contain exactly one Value.
+13:52:13 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: AdditionalItemProperty MUST contain exactly one Value.
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-INFERRED-CARDINALITY-T77.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 1) Verify that validity period end date is equal to or later than the issue
+			date
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 2) Verify that validity period end date is equal to or later than the issue
+			date
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 3) Verify that validity period end date is equal to or later than the issue
+			date
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 4) Verify that validity period end date is equal to or later than the issue
+			date
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R001.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 1) Verify shopping cart lines quantities are greater than zero
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 2) Verify shopping cart lines quantities are greater than zero
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 3) Verify shopping cart lines quantities are greater than zero
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R002.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 1) Verify that prices must not be negative
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 2) Verify that prices must not be negative
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 3) Verify that prices must not be negative
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R003.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 1) Verify that either “item sellers identifier” or “item standard identifier” is specified
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 2) Verify that either “item sellers identifier” or “item standard identifier” is specified
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 3) Verify that either “item sellers identifier” or “item standard identifier” is specified
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 4) Verify that either “item sellers identifier” or “item standard identifier” is specified
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R004.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 1) Verify that only one attachment is used for the main image"
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 2) Verify that only one attachment is used for the main image"
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:14 INFO  ValidationInstance -   Detected expectation: 3) Verify that only one attachment is used for the main image"
+13:52:14 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:14 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:14 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R005.xml'
+13:52:14 INFO  ValidationInstance - Loading document from stream
+13:52:14 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 1) Verify Unit code for price base quantity is same as for batch
+			quantity.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 2) Verify Unit code for price base quantity is same as for batch
+			quantity.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 3) Verify Unit code for price base quantity is same as for batch
+			quantity.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 4) Verify Unit code for price base quantity is same as for batch
+			quantity.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R006.xml'
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 1) Verify that for AdditionalItemProperties where name is ServiceIndicator the value MUST be "true" OR "false"
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 2) Verify that for AdditionalItemProperties where name is ServiceIndicator the value MUST be "true" OR "false"
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 3) Verify that for AdditionalItemProperties where name is ServiceIndicator the value MUST be "true" OR "false"
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 4) Verify that for AdditionalItemProperties where name is ServiceIndicator the value MUST be "true" OR "false"
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R007.xml'
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 1) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 2) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 3) Verify that all TaxCategories have a VAT rate, except if the catalogue is not
+			subject to VAT.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R008.xml'
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: 3) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  Tester - TestSet '/src/rules/unit-punch-out/PEPPOL-T77-R009.xml'
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: AccountingCustomerParty MUST contain exactly one Party.
+13:52:15 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:15 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:15 INFO  ValidationInstance - Loading document from stream
+13:52:15 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:15 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: AccountingCustomerParty MUST contain exactly one Party.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-INFERRED-CARDINALITY-T114.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Correct use of allowance codes.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-CL001.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Correct use of charge codes.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-CL002.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Verify line identifier is unique within the order change
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 2) Verify line identifier is unique within the order change
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 3) Verify line identifier is unique within the order change
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R001.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 2) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 3) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 4) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 5) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R003.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Verify that line quantity is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 2) Verify that line quantity is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 3) Verify that line quantity is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R004.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Verify that price amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 2) Verify that price amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 3) Verify that price amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R005.xml'
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected payable amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected payable amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  ValidationInstance - Loading document from stream
+13:52:16 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:16 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected payable amount is not negative
+13:52:16 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:16 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:16 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R006.xml'
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected total sum of line amounts is not negative
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected total sum of line amounts is not negative
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected total sum of line amounts is not negative
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R007.xml'
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 1) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 2) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 3) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 4) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 5) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 6) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 7) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 8) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 9) Verify that total sum of line amounts equal the sum of the order line amounts at order line level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R008.xml'
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total sum of allowance at document level is equal to
+			the sum of allowance amounts at document level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:17 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R009.xml'
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:17 INFO  ValidationInstance - Loading document from stream
+13:52:17 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:17 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:17 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:17 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total sum of charges at document level is equal to
+			the sum of charge amounts at document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R010.xml'
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 1) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 2) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 3) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 4) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 5) Verify that the expected total amount without VAT = Expected total sum of line amounts - Sum of allowances on document level + Sum of charges on document level
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R011.xml'
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 1) Verify that each order line SHOULD have an ordered quantity
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 2) Verify that each order line SHOULD have an ordered quantity
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R013.xml'
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 1) Verify Order originator name or identifier is specified
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 2) Verify Order originator name or identifier is specified
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 3) Verify Order originator name or identifier is specified
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:18 INFO  ValidationInstance -   Detected expectation: 4) Verify Order originator name or identifier is specified
+13:52:18 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:18 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:18 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R014.xml'
+13:52:18 INFO  ValidationInstance - Loading document from stream
+13:52:18 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 1) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 2) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 3) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 4) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 5) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 6) Verify that Amount due for payment = Invoice total amount with VAT - Paid amount + Rounding amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R016.xml'
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 1) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 2) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 3) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 4) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 5) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 6) Verify that expected total amount with VAT = Expected total amount without VAT
+			+ Order total VAT amount.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R017.xml'
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 1) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 2) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 3) Verify that item net price equals (Gross price - Allowance amount), when gross
+			price is provided
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R019.xml'
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:19 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/charge base amount is provided when allowance/charge percentage is provided.
+13:52:19 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:19 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:19 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R020.xml'
+13:52:19 INFO  ValidationInstance - Loading document from stream
+13:52:19 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/chargepercentage is provided when allowance/charge base amount is provided.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R021.xml'
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 4) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 5) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 6) Verify that allowance/charge amount equal base amount * percentage/100, if base
+			amount and percentage exists.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R022.xml'
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 1) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 2) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 3) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 4) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 5) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 6) Verify that each document or line level allowance have an allowance reason text or an allowance reason code.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:20 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R023.xml'
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:20 INFO  ValidationInstance - Loading document from stream
+13:52:20 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:20 INFO  ValidationInstance -   Detected expectation: 1) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:20 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:20 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 2) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 3) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 4) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 5) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 6) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 7) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 8) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 9) Verify that order line net amount equal (Ordered quantity * (Item net price/item price base quantity) + Order line charge amount - Order line allowance amount.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R024.xml'
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 1) Verify that base quantity is be a positive number above zero.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 2) Verify that base quantity is be a positive number above zero.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 3) Verify that base quantity is be a positive number above zero.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 4) Verify that base quantity is be a positive number above zero.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R025.xml'
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 1) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified.
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 2) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified.
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 3) Verify that the party VAT identifiers have a prefix in accordance with ISO code ISO 3166-1 alpha-2 by which the country of issue may be identified.
+			Nevertheless, Greece may use the prefix ‘EL’.
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R026.xml'
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 1) Verify that item gross price is not negative
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 2) Verify that item gross price is not negative
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 3) Verify that item gross price is not negative
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R027.xml'
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 1) Verify that all elements with datatype amount has maximum 2 decimals
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:21 INFO  ValidationInstance -   Detected expectation: 2) Verify that all elements with datatype amount has maximum 2 decimals
+13:52:21 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:21 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:21 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R028.xml'
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:21 INFO  ValidationInstance - Loading document from stream
+13:52:21 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that all TaxCategories have a VAT rate, except if the order change is not
+			subject to VAT.
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 2) Verify that all TaxCategories have a VAT rate, except if the order change is not
+			subject to VAT.
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 3) Verify that all TaxCategories have a VAT rate, except if the order change is not
+			subject to VAT.
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R029.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 2) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 3) Verify that VAT rate is higher than zero(0) if VAT category is "S" (standard
+			rate)
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R030.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that ProfileID is correct
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R031.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that allowance amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 2) Verify that allowance amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 3) Verify that allowance amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R032.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that any allowance charge amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 2) Verify that any allowance charge amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 3) Verify that any allowance charge amounts are not negative
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-change/PEPPOL-T114-R033.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-cancellation/PEPPOL-INFERRED-CARDINALITY-T115.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 1) Verify that the buyer party official name or a buyer party identifier exists
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 2) Verify that the buyer party official name or a buyer party identifier exists
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:22 INFO  ValidationInstance -   Detected expectation: 3) Verify that the buyer party official name or a buyer party identifier exists
+13:52:22 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:22 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:22 INFO  Tester - TestSet '/src/rules/unit-order-cancellation/PEPPOL-T115-R001.xml'
+13:52:22 INFO  ValidationInstance - Loading document from stream
+13:52:22 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: success) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: error) Verify inferred mandatory cardinality: BuyerCustomerParty MUST contain exactly one Party.
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-INFERRED-CARDINALITY-T116.xml'
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 1) Verify that the buyer party official name or a buyer party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 2) Verify that the buyer party official name or a buyer party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 3) Verify that the buyer party official name or a buyer party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 4) Verify that the buyer party official name or a buyer party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 5) Verify that the buyer party official name or a buyer party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R001.xml'
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 1) Verify that the seller party official name or a seller party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 2) Verify that the seller party official name or a seller party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 3) Verify that the seller party official name or a seller party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 4) Verify that the seller party official name or a seller party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 5) Verify that the seller party official name or a seller party identifier
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R002.xml'
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 1) Verify line identifier is unique within the order response
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 2) Verify line identifier is unique within the order response
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 3) Verify line identifier is unique within the order response
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R003.xml'
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 1) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:23 INFO  ValidationInstance - Loading document from stream
+13:52:23 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:23 INFO  ValidationInstance -   Detected expectation: 2) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:23 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:23 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 3) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 4) Verify that if a delivery period has a start date and an end date, the end date
+			is equal to, or later than the start date 
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R004.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 1) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 2) Verify currencyID has same value as DocumentCurrencyCode.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R005.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 1) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 2) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 3) An order response with code CA (Conditionally accepted) must provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R007.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 1) An order response with code AP (Accepted) must NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 2) An order response with code AP (Accepted) must NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R008.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 1) An order response with code RE (Rejected) should NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 2) An order response with code RE (Rejected) should NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R009.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.testset (with children)
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 1) An order response with code AB (Acknowledged) must NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.test (with converter)
+13:52:24 INFO  ValidationInstance -   Detected expectation: 2) An order response with code AB (Acknowledged) must NOT provide order lines.
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - TestSet '/src/rules/unit-order-response-advanced/PEPPOL-T116-R010.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc1/OrderCancellation_sc1.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [5871 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc1/OrderChange_sc1.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [3004 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc1/OrderResponse_sc1.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [5313 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc1/Order_sc1.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [5720 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc2/OrderChange_sc2.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [1998 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc2/OrderResponse_sc2.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc3/OrderCancellation_sc3.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [5736 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc3/OrderChange_sc3.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [2920 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc3/OrderResponse_sc3.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:24 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc4/OrderCancellation_sc4.xml'
+13:52:24 INFO  ValidationInstance - Loading document from stream
+13:52:24 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:24 INFO  ValidationInstance -   Detected expectation: XML expectation [1724 bytes]
+13:52:24 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:24 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc4/OrderResponse_sc4.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1890 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc5/OrderCancellation_sc5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1710 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Advanced Ordering scenarios/advanced_ordering_sc5/OrderResponse_sc5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [17592 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [9703 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-2.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [27457 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-3.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [4892 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-4.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [13357 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [6540 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Cataloge wo response use cases/catalogue-wo-response-use-case-6.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1579 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T58.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/CatalogueResponse_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [11662 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Catalogue_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [6253 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Despatch Advice use cases/DespatchAdvice-BIS3_UseCase1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [9526 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Despatch Advice use cases/DespatchAdvice-BIS3_UseCase2.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [9766 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Despatch Advice use cases/DespatchAdvice-BIS3_UseCase3.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [8669 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Despatch Advice use cases/DespatchAdvice-BIS3_UseCase4.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [13130 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Despatch Advice use cases/DespatchAdvice-BIS3_UseCase5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Full BIS3 Peppol UBL Despatch Adivce.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/DespatchAdvice_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 1 — Invoice in process
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc001-Invoice in process.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 2a — Invoice in process with additional reference date.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc002a-Additional reference data.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 2b — Invoice is in process but processing is postponed.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc002b-In process but postponed.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 3 — Invoice is accepted
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc003-Invoice is accepted.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 4a — Invoice is rejected
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc004a-Invoice is rejected.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 4b — Invoice is rejected requesting re-issue
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc004b-Rejected requesting reissue.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 4c — Invoice is rejected requesting replacement.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc004c-Rejected requesting replacement.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 5 — Invoice is rejected requesting replacement.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc005-Invoice is conditionally accepted.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 6a — Invoice is under query because of wrong or missing information.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc006a-Under query missing information.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 6a — Invoice is under query because of wrong or missing information.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc006b-Missing PO.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 6c — Invoice is under query because of wrong detail. Partial credit note is requested.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc006c-Wrong detail partial credit.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 7 — Payment has been initiated.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc007-Payment has been initiated.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 8 — Invoice is accepted by third party who acts on behalf of Buyer.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc008-Invoice is accepted by third party.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Peppol Invoice Response, profile 63. It demonstrates Use Case 9 - Self-billed invoice is rejected by the Seller.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Invoice reponse use cases/T111-uc009-Self-billed invoice is rejected.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Full BIS3 Peppol UBL Invoice Response.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T111.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/InvoiceResponse_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Full BIS3 Peppol UBL MLR.
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/MessageLevelResponse_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [7505 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC1_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [6486 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC2_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [4827 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC3_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [11645 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC4_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [8252 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC5_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [3998 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order use cases/UC6_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [3821 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order-response use cases/UC1_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [3018 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order-response use cases/UC2_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1527 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order-response use cases/UC3_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [2712 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order-response use cases/UC4_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1402 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order-response use cases/UC5_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: This file contains a Full BIS3 Peppol UBL Order Agreement
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/OrderAgreement_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1883 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/OrderCancellation_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5875 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/OrderChange_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [4657 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/OrderResponseAdvanced_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5736 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/OrderResponse_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [17098 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/Order_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [6724 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/examples/PunchOut_Example.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [7505 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order/UC1_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [6486 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order/UC2_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [4827 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order/UC3_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [11433 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order/UC4_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [8252 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order/UC5_Order.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [3821 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order-response/UC1_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1875 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order-response/UC2_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1527 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order-response/UC3_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [2712 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order-response/UC4_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1402 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/order-response/UC5_Order_response.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc1/OrderCancellation_sc1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5675 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc1/OrderChange_sc1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [3004 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc1/OrderResponse_sc1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5313 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc1/Order_sc1.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5715 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc2/OrderChange_sc2.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1998 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc2/OrderResponse_sc2.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc3/OrderCancellation_sc3.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [5731 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc3/OrderChange_sc3.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [2920 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc3/OrderResponse_sc3.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1888 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc4/OrderCancellation_sc4.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1724 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc4/OrderResponse_sc4.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1890 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc5/OrderCancellation_sc5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [1708 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T116.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/use-case-examples/advanced-ordering-sc5/OrderResponse_sc5.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [12334 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/snippets/order/snippet-01.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [7439 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/snippets/order/snippet-02.xml'
+13:52:25 INFO  ValidationInstance - Loading document from stream
+13:52:25 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:25 INFO  ValidationInstance -   Detected expectation: XML expectation [7452 bytes]
+13:52:25 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T01.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:25 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:25 INFO  Tester - Test '/src/rules/snippets/order/snippet-advanced.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [9480 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-response/snippet-1.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [1775 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T76.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-response/snippet-2.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [11040 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-agreement/OA full.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [9762 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T110.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-agreement/snippet-oa.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [13654 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/catalogue/Snippet-1-1.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [8897 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T19.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/catalogue/Snippet-1-2.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [8740 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/punchout/snippet-18-1.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [9209 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T77.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/punchout/snippet-18-2.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [8111 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/despatch/snippet-30-1.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [6280 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/despatch/snippet-30-2.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [6314 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/despatch/snippet-30-3.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [8194 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T16.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/despatch/snippet-30-4.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [1535 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/mlr/snippet-1.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [1213 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/mlr/snippet-2.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [2842 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T71.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/mlr/snippet-3.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [10398 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T114.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-change/snippet-advanced.xml'
+13:52:26 INFO  ValidationInstance - Loading document from stream
+13:52:26 INFO  ValidationInstance -   Detected declaration: xml.ubl
+13:52:26 INFO  ValidationInstance -   Detected expectation: XML expectation [2177 bytes]
+13:52:26 INFO  ValidationInstance - Validating 'eu.peppol.poacc.upgrade.v3-813fec94-2f8f-48f7-86ba-4adc76ed7c09.asice#xsl/PEPPOLBIS-T115.xsl' with Engine [PEPPOL BIS Upgrade 3.0]
+13:52:26 INFO  SchematronXsltChecker - Running Schematron XSTL-based validation
+13:52:26 INFO  Tester - Test '/src/rules/snippets/order-cancellation/snippet-advanced.xml'
+13:52:26 INFO  Tester - 718 tests performed, 0 tests failed
+remove "C:\Data\Peppol\POACC\poacc-upgrade-3\target\site\files\PEPPOLBIS-Upgrade-Schematron.zip"
+remove C:\Data\Peppol\POACC\poacc-upgrade-3\target\site\files\PEPPOLBIS-Examples.zip
+Document: ./guides/changes/main.adoc
+Document: ./guides/compliance/main.adoc
+Document: ./guides/methodology/main.adoc
+Document: ./guides/methodology/schematron/main.adoc
+Document: ./guides/migration/main.adoc
+Document: ./guides/profiles/1-catalogueonly/main.adoc
+Document: ./guides/profiles/18-punchout/main.adoc
+Document: ./guides/profiles/28-ordering/main.adoc
+Document: ./guides/profiles/3-order-only/main.adoc
+Document: ./guides/profiles/30-despatchadvice/main.adoc
+Document: ./guides/profiles/36-mlr/main.adoc
+Document: ./guides/profiles/42-orderagreement/main.adoc
+Document: ./guides/profiles/63-invoiceresponse/main.adoc
+Document: ./guides/profiles/64-catalogue-wo-response/main.adoc
+Document: ./guides/profiles/65-advanced-ordering/main.adoc
+Document: ./guides/profiles/66-billing-with-response/main.adoc
+Document: ./guides/profiles/99-Sandbox/main.adoc
+Document: ./guides/release-notes/3-0-0/main.adoc
+Document: ./guides/release-notes/main.adoc
+Document: ./guides/review/main.adoc
+Document: ./guides/work/main.adoc
+Document: ./guides/work/rules/main.adoc
+Assets: ./guides/methodology/images
+Assets: ./guides/profiles/1-catalogueonly/images
+Assets: ./guides/profiles/18-punchout/images
+Assets: ./guides/profiles/28-ordering/images
+Assets: ./guides/profiles/3-order-only/images
+Assets: ./guides/profiles/30-despatchadvice/images
+Assets: ./guides/profiles/36-mlr/images
+Assets: ./guides/profiles/42-orderagreement/images
+Assets: ./guides/profiles/63-invoiceresponse/images
+Assets: ./guides/profiles/64-catalogue-wo-response/images
+Assets: ./guides/profiles/65-advanced-ordering/images
+Assets: ./guides/profiles/99-Sandbox/images
+Assets: ./guides/shared/images

--- a/build.sh
+++ b/build.sh
@@ -23,6 +23,16 @@ docker run --rm -i \
     -v $PROJECT/target:/target \
     difi/vefa-structure:0.6.1
 
+# Inferred mandatory cardinality, excluding asserts already covered by generated Txx-basic.sch
+if command -v pwsh >/dev/null 2>&1; then
+    pwsh -NoProfile -File "$PROJECT/tools/audit-inferred-mandatory-cardinality.ps1" || exit $?
+elif command -v powershell >/dev/null 2>&1; then
+    powershell -NoProfile -File "$PROJECT/tools/audit-inferred-mandatory-cardinality.ps1" || exit $?
+else
+    echo "ERROR: PowerShell is required to compare inferred cardinality rules with generated basic Schematron." >&2
+    exit 1
+fi
+
 # Testing validation rules
 docker run --rm -i -v $PROJECT:/src phelger/vefa-validator:2.4.3 build -x -t -n eu.peppol.poacc.upgrade.v3 -a rules -target target/validator-test /src
 
@@ -36,7 +46,7 @@ docker run --rm -i -v $PROJECT:/src alpine:3.11 chown -R $(id -g $USER).$(id -g 
 BUILD_RESULT=$?
 
 printf '\nWarnings and errors from %s:\n' "$BUILD_LOG" >&3
-if ! grep -nEi '(^|\|-|\[)(WARN(ING)?|ERROR)([[:space:]:\]]|$)' "$BUILD_LOG" >&3; then
+if ! grep -nE '([0-9]{2}:[0-9]{2}:[0-9]{2}([.,][0-9]{1,3})?[[:space:]]+(\|[[:space:]]*-?)?(WARN(ING)?|ERROR).+)' "$BUILD_LOG" >&3; then
     echo "None." >&3
 fi
 

--- a/build.sh
+++ b/build.sh
@@ -23,16 +23,6 @@ docker run --rm -i \
     -v $PROJECT/target:/target \
     difi/vefa-structure:0.6.1
 
-# Inferred mandatory cardinality, excluding asserts already covered by generated Txx-basic.sch
-if command -v pwsh >/dev/null 2>&1; then
-    pwsh -NoProfile -File "$PROJECT/tools/audit-inferred-mandatory-cardinality.ps1" || exit $?
-elif command -v powershell >/dev/null 2>&1; then
-    powershell -NoProfile -File "$PROJECT/tools/audit-inferred-mandatory-cardinality.ps1" || exit $?
-else
-    echo "ERROR: PowerShell is required to compare inferred cardinality rules with generated basic Schematron." >&2
-    exit 1
-fi
-
 # Testing validation rules
 docker run --rm -i -v $PROJECT:/src phelger/vefa-validator:2.4.3 build -x -t -n eu.peppol.poacc.upgrade.v3 -a rules -target target/validator-test /src
 

--- a/guides/release-notes/v3.0.18.adoc
+++ b/guides/release-notes/v3.0.18.adoc
@@ -28,4 +28,6 @@ Release date:: November 2026
 * Removed rules PEPPOL-T01-R002 and PEPPOL-T114-R002 (warning) which required Order and OrderChange to allways provide a validity end date.
 
 == Other changes
+* removed an unknown codelist reference "2" from catalogue OrderableUnitFactorRate.
+* added missing test folders for catalogue-response and mlr
 

--- a/rules/buildconfig.xml
+++ b/rules/buildconfig.xml
@@ -5,9 +5,11 @@
 
 <!-- unit testing -->
   <testfolder>unit-catalogue</testfolder>
+  <testfolder>unit-catalogue-response</testfolder>
   <testfolder>unit-common</testfolder>
   <testfolder>unit-despatch-advice</testfolder>
   <testfolder>unit-invoice-response</testfolder>
+  <testfolder>unit-mlr</testfolder>
   <testfolder>unit-order</testfolder>
   <testfolder>unit-order-agreement</testfolder>
   <testfolder>unit-order-response</testfolder>

--- a/structure/syntax/ubl-catalogue.xml
+++ b/structure/syntax/ubl-catalogue.xml
@@ -1365,7 +1365,7 @@
                             Quantity. If not present, assumed value is 1</Description>
 						<DataType>Text</DataType>
 						<Reference type="BUSINESS_TERM">tir19-p035</Reference>
-						<Reference type="CODE_LIST">2</Reference>
+						<!--Reference type="CODE_LIST">2</Reference-->
 						<Value type="EXAMPLE">1</Value>
 					</Element>
 

--- a/tools/audit-inferred-mandatory-cardinality.ps1
+++ b/tools/audit-inferred-mandatory-cardinality.ps1
@@ -1,0 +1,546 @@
+[CmdletBinding()]
+param(
+    [string]$OutputPath = 'target/generated/inferred-cardinality-namespace-audit.csv',
+    [string]$SchematronOutputDirectory = 'rules/sch/parts',
+    [string]$GeneratedSchematronDirectory = 'target/generated',
+    [string]$ExclusionLogPath = 'target/generated/inferred-cardinality-excluded.csv'
+)
+
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = Split-Path -Parent $PSScriptRoot
+$syntaxDirectory = Join-Path $repositoryRoot 'structure/syntax'
+$namespaceDirectory = Join-Path $repositoryRoot 'structure/namespace'
+
+function Read-XmlDocument {
+    param([string]$Path)
+
+    $document = [System.Xml.XmlDocument]::new()
+    $document.Load($Path)
+    return $document
+}
+
+function Get-ChildElementsByLocalName {
+    param(
+        [System.Xml.XmlNode]$Node,
+        [string]$LocalName
+    )
+
+    return @($Node.ChildNodes | Where-Object {
+        $_.NodeType -eq [System.Xml.XmlNodeType]::Element -and $_.LocalName -eq $LocalName
+    })
+}
+
+function Get-FirstChildText {
+    param(
+        [System.Xml.XmlNode]$Node,
+        [string]$LocalName
+    )
+
+    if (-not $Node) {
+        return $null
+    }
+
+    $child = $Node.SelectSingleNode("*[local-name()='$LocalName']")
+    if (-not $child) {
+        return $null
+    }
+
+    return $child.InnerText.Trim()
+}
+
+function ConvertTo-XmlAttribute {
+    param([string]$Value)
+
+    return ((($Value -replace '&', '&amp;') -replace '"', '&quot;') -replace '<', '&lt;') -replace '>', '&gt;'
+}
+
+function ConvertFrom-NamespaceFile {
+    param([string]$Path)
+
+    $document = Read-XmlDocument $Path
+    $identifierNode = $document.SelectSingleNode("/*[local-name()='Namespace']/*[local-name()='Identifier']")
+    $elements = @{}
+
+    foreach ($element in @($document.SelectNodes("/*[local-name()='Namespace']/*[local-name()='Element']"))) {
+        $name = $element.GetAttribute('name')
+        if (-not $name) {
+            continue
+        }
+
+        $refs = @{}
+        foreach ($ref in (Get-ChildElementsByLocalName -Node $element -LocalName 'Ref')) {
+            $term = $ref.InnerText.Trim()
+            if (-not $term) {
+                continue
+            }
+
+            $refs[$term] = if ($ref.HasAttribute('card')) { $ref.GetAttribute('card') } else { $null }
+        }
+
+        $elements[$name] = $refs
+    }
+
+    return [pscustomobject]@{
+        Path = $Path
+        FileName = [System.IO.Path]::GetFileName($Path)
+        Identifier = if ($identifierNode) { $identifierNode.InnerText.Trim() } else { $null }
+        Prefix = if ($identifierNode -and $identifierNode.HasAttribute('prefix')) { $identifierNode.GetAttribute('prefix') } else { $null }
+        Elements = $elements
+    }
+}
+
+function ConvertFrom-AllNamespaceFiles {
+    $files = @{}
+    foreach ($file in @(Get-ChildItem -Path $namespaceDirectory -Filter '*.xml' -File)) {
+        $files[$file.Name] = ConvertFrom-NamespaceFile $file.FullName
+    }
+    return $files
+}
+
+function Resolve-DocumentNamespace {
+    param(
+        [hashtable]$NamespaceFiles,
+        [string]$SyntaxFileName,
+        [string]$DocumentUri,
+        [string]$RootLocalName
+    )
+
+    if ($NamespaceFiles.ContainsKey($SyntaxFileName)) {
+        return $NamespaceFiles[$SyntaxFileName]
+    }
+
+    $matches = @(
+        $NamespaceFiles.Values |
+            Where-Object { $_.Identifier -eq $DocumentUri -and $_.Elements.ContainsKey($RootLocalName) } |
+            Sort-Object { $_.FileName.Length }
+    )
+
+    if ($matches.Count -gt 0) {
+        return $matches[0]
+    }
+
+    return $null
+}
+
+function Get-IncludedElements {
+    param([string]$IncludePath)
+
+    $includeDocument = Read-XmlDocument $IncludePath
+    if ($includeDocument.DocumentElement.LocalName -eq 'Element') {
+        return @($includeDocument.DocumentElement)
+    }
+
+    return @(Get-ChildElementsByLocalName -Node $includeDocument.DocumentElement -LocalName 'Element')
+}
+
+function Get-NamespaceCardinality {
+    param(
+        [hashtable]$Indexes,
+        [string]$ParentPrefix,
+        [string]$ParentName,
+        [string]$Term
+    )
+
+    if (-not $ParentPrefix -or -not $ParentName -or -not $Indexes.ContainsKey($ParentPrefix)) {
+        return 'UNRESOLVED'
+    }
+
+    $parentRefs = $Indexes[$ParentPrefix].Elements[$ParentName]
+    if (-not $parentRefs -or -not $parentRefs.ContainsKey($Term) -or [string]::IsNullOrWhiteSpace($parentRefs[$Term])) {
+        return 'UNRESOLVED'
+    }
+
+    return $parentRefs[$Term]
+}
+
+function ConvertTo-SchematronContext {
+    param([string]$ElementPath)
+
+    $segments = @($ElementPath -split '/')
+    if ($segments.Count -lt 2) {
+        return $segments[0]
+    }
+
+    return ($segments[0..($segments.Count - 2)] -join '/')
+}
+
+function ConvertTo-NormalizedSchematronContext {
+    param([string]$Context)
+
+    if ([string]::IsNullOrWhiteSpace($Context)) {
+        return ''
+    }
+
+    return $Context.Trim().TrimStart('/')
+}
+
+function ConvertFrom-GeneratedMandatoryTest {
+    param([string]$Test)
+
+    if ([string]::IsNullOrWhiteSpace($Test)) {
+        return $null
+    }
+
+    $normalized = [regex]::Replace($Test.Trim(), '\s+', ' ')
+
+    if ($normalized -match '^count\(\s*([A-Za-z_][\w.-]*:[A-Za-z_][\w.-]*)\s*\)\s*(=|eq)\s*1$') {
+        return [pscustomobject]@{
+            Child = $Matches[1]
+            Strictness = 'repeatability'
+            StrictnessLabel = 'strict on repeatability (exactly one)'
+        }
+    }
+
+    if ($normalized -match '^exists\(\s*([A-Za-z_][\w.-]*:[A-Za-z_][\w.-]*)\s*\)$') {
+        return [pscustomobject]@{
+            Child = $Matches[1]
+            Strictness = 'existence'
+            StrictnessLabel = 'existence only (not strict on repeatability)'
+        }
+    }
+
+    if ($normalized -match '^count\(\s*([A-Za-z_][\w.-]*:[A-Za-z_][\w.-]*)\s*\)\s*(>|>=|gt|ge)\s*(0|1)$') {
+        return [pscustomobject]@{
+            Child = $Matches[1]
+            Strictness = 'existence'
+            StrictnessLabel = 'existence only (not strict on repeatability)'
+        }
+    }
+
+    if ($normalized -match '^([A-Za-z_][\w.-]*:[A-Za-z_][\w.-]*)$') {
+        return [pscustomobject]@{
+            Child = $Matches[1]
+            Strictness = 'existence'
+            StrictnessLabel = 'existence only (not strict on repeatability)'
+        }
+    }
+
+    return $null
+}
+
+function Get-GeneratedMandatoryCoverage {
+    param(
+        [string]$GeneratedDirectory,
+        [string]$TransactionId
+    )
+
+    $coverage = @{}
+    $path = Join-Path $GeneratedDirectory "$TransactionId-basic.sch"
+    if (-not (Test-Path -LiteralPath $path)) {
+        return $coverage
+    }
+
+    $document = Read-XmlDocument $path
+    foreach ($rule in @($document.SelectNodes("//*[local-name()='rule']"))) {
+        $context = ConvertTo-NormalizedSchematronContext $rule.GetAttribute('context')
+        if (-not $context) {
+            continue
+        }
+
+        foreach ($assert in @($rule.SelectNodes("*[local-name()='assert']"))) {
+            $parsed = ConvertFrom-GeneratedMandatoryTest -Test $assert.GetAttribute('test')
+            if (-not $parsed) {
+                continue
+            }
+
+            $key = "$context|$($parsed.Child)"
+            $entry = [pscustomobject]@{
+                Id = $assert.GetAttribute('id')
+                Test = $assert.GetAttribute('test')
+                Child = $parsed.Child
+                Strictness = $parsed.Strictness
+                StrictnessLabel = $parsed.StrictnessLabel
+            }
+
+            if (-not $coverage.ContainsKey($key)) {
+                $coverage[$key] = $entry
+            }
+            elseif ($entry.Strictness -eq 'repeatability' -and $coverage[$key].Strictness -ne 'repeatability') {
+                $coverage[$key] = $entry
+            }
+        }
+    }
+
+    return $coverage
+}
+
+function Write-InferredCardinalitySchematron {
+    param(
+        [string]$Path,
+        [string]$TransactionId,
+        [object[]]$AssertionRows
+    )
+
+    if (-not $AssertionRows) {
+        $AssertionRows = @()
+    }
+
+    $rules = @(
+        $AssertionRows |
+            Group-Object Context |
+            ForEach-Object {
+                $context = ConvertTo-XmlAttribute $_.Name
+                $assertions = $_.Group | ForEach-Object {
+                    $id = ConvertTo-XmlAttribute $_.Id
+                    $child = ConvertTo-XmlAttribute $_.Child
+                    "    <assert id=`"$id`" test=`"count($child) = 1`" flag=`"fatal`">[$id]-$context MUST contain exactly one $child.</assert>"
+                }
+                "  <rule context=`"$context`">`n$($assertions -join "`n")`n  </rule>"
+            }
+    )
+
+    $utf8NoBom = [System.Text.UTF8Encoding]::new($false)
+    [System.IO.File]::WriteAllLines(
+        $Path,
+        @(
+            '<?xml version="1.0" encoding="UTF-8"?>'
+            "<pattern xmlns=`"http://purl.oclc.org/dsdl/schematron`" id=`"PEPPOL-M-$TransactionId-I`">"
+            $rules
+            '</pattern>'
+        ),
+        $utf8NoBom
+    )
+
+    return $rules.Count
+}
+
+function Resolve-StructureElements {
+    param(
+        [System.Xml.XmlNode[]]$Nodes,
+        [string]$DocumentName,
+        [string]$TransactionId,
+        [string]$RulePrefix,
+        [string]$SourceFile,
+        [string]$Path,
+        [string]$ParentCardinality,
+        [string]$ParentPrefix,
+        [string]$ParentName,
+        [hashtable]$Indexes,
+        [System.Collections.Generic.List[object]]$Rows
+    )
+
+    foreach ($node in $Nodes) {
+        if ($node.LocalName -eq 'Include') {
+            $includePath = Join-Path (Split-Path -Parent ([Uri]$node.BaseURI).LocalPath) $node.InnerText.Trim()
+            Resolve-StructureElements `
+                -Nodes (Get-IncludedElements $includePath) `
+                -DocumentName $DocumentName `
+                -TransactionId $TransactionId `
+                -RulePrefix $RulePrefix `
+                -SourceFile $SourceFile `
+                -Path $Path `
+                -ParentCardinality $ParentCardinality `
+                -ParentPrefix $ParentPrefix `
+                -ParentName $ParentName `
+                -Indexes $Indexes `
+                -Rows $Rows
+            continue
+        }
+
+        if ($node.LocalName -ne 'Element') {
+            continue
+        }
+
+        $term = Get-FirstChildText -Node $node -LocalName 'Term'
+        if (-not $term) {
+            continue
+        }
+
+        $elementPath = if ($Path) { "$Path/$term" } else { $term }
+        $namespaceCardinality = Get-NamespaceCardinality -Indexes $Indexes -ParentPrefix $ParentPrefix -ParentName $ParentName -Term $term
+        $cardinality = if ($node.Attributes['cardinality']) { $node.Attributes['cardinality'].Value } else { '1..1' }
+
+        if (-not $node.Attributes['cardinality']) {
+            $references = @(
+                $node.SelectNodes("*[local-name()='Reference' and @type='BUSINESS_TERM']") |
+                    ForEach-Object { $_.InnerText.Trim() }
+            ) -join ', '
+
+            $Rows.Add([pscustomobject]@{
+                Document = $DocumentName
+                TransactionId = $TransactionId
+                RulePrefix = $RulePrefix
+                SourceFile = $SourceFile
+                Path = $elementPath
+                BusinessTerms = $references
+                SyntaxExplicitCardinality = 'NO'
+                SyntaxGeneratedCardinality = '1..1'
+                ParentSyntaxCardinality = $ParentCardinality
+                NamespaceCardinality = $namespaceCardinality
+                NamespaceDiffersFromGeneratedMandatory = if ($namespaceCardinality -eq '1..1') { 'NO' } else { 'YES' }
+            })
+        }
+
+        $childPrefix = $ParentPrefix
+        $childName = $ParentName
+        if ($term.Contains(':')) {
+            $childPrefix = $term.Split(':')[0]
+            $childName = $term.Split(':')[-1]
+        }
+
+        Resolve-StructureElements `
+            -Nodes @($node.ChildNodes) `
+            -DocumentName $DocumentName `
+            -TransactionId $TransactionId `
+            -RulePrefix $RulePrefix `
+            -SourceFile $SourceFile `
+            -Path $elementPath `
+            -ParentCardinality $cardinality `
+            -ParentPrefix $childPrefix `
+            -ParentName $childName `
+            -Indexes $Indexes `
+            -Rows $Rows
+    }
+}
+
+$namespaceFiles = ConvertFrom-AllNamespaceFiles
+$cacNamespace = $namespaceFiles['ubl-cac.xml']
+$cbcNamespace = $namespaceFiles['ubl-cbc.xml']
+if (-not $cacNamespace -or -not $cbcNamespace) {
+    throw "Missing shared namespace files ubl-cac.xml and/or ubl-cbc.xml in $namespaceDirectory"
+}
+
+$rows = [System.Collections.Generic.List[object]]::new()
+$processedTransactionIds = [System.Collections.Generic.List[string]]::new()
+
+foreach ($syntaxPath in @(Get-ChildItem -Path $syntaxDirectory -Filter '*.xml' -File | ForEach-Object { $_.FullName } | Sort-Object)) {
+    $structure = Read-XmlDocument $syntaxPath
+    $root = $structure.SelectSingleNode("/*[local-name()='Structure']/*[local-name()='Document']")
+    if (-not $root) {
+        Write-Warning "Skipping $syntaxPath because it has no Document element."
+        continue
+    }
+
+    $documentName = Get-FirstChildText -Node $structure.DocumentElement -LocalName 'Term'
+    $rulePrefixNode = $structure.SelectSingleNode("/*[local-name()='Structure']/*[local-name()='Property' and @key='sch:prefix']")
+    $rulePrefix = if ($rulePrefixNode) { $rulePrefixNode.InnerText.Trim() } else { $null }
+    $identifierNode = $structure.SelectSingleNode("/*[local-name()='Structure']/*[local-name()='Property' and @key='sch:identifier']")
+    $identifier = if ($identifierNode) { $identifierNode.InnerText.Trim() } else { $null }
+    $transactionId = if ($identifier) {
+        $identifier -replace '-basic$', ''
+    } elseif ($rulePrefix -match 'T\d+$') {
+        $Matches[0]
+    } else {
+        $documentName
+    }
+    $processedTransactionIds.Add($transactionId)
+    $documentTerm = Get-FirstChildText -Node $root -LocalName 'Term'
+    $documentUri = $structure.SelectSingleNode("/*[local-name()='Structure']/*[local-name()='Namespace' and @prefix='ubl']").InnerText.Trim()
+    $rootLocalName = $documentTerm.Split(':')[-1]
+    $syntaxFileName = [System.IO.Path]::GetFileName($syntaxPath)
+    $documentNamespace = Resolve-DocumentNamespace -NamespaceFiles $namespaceFiles -SyntaxFileName $syntaxFileName -DocumentUri $documentUri -RootLocalName $rootLocalName
+    if (-not $documentNamespace) {
+        throw "Could not resolve a namespace file for $syntaxFileName ($documentUri / $rootLocalName)."
+    }
+
+    $indexes = @{
+        ubl = $documentNamespace
+        cac = $cacNamespace
+        cbc = $cbcNamespace
+    }
+    if ($documentNamespace.Prefix -and -not $indexes.ContainsKey($documentNamespace.Prefix)) {
+        $indexes[$documentNamespace.Prefix] = $documentNamespace
+    }
+
+    $relativeSource = $syntaxPath.Substring((Join-Path $repositoryRoot '').Length)
+    Resolve-StructureElements `
+        -Nodes @($root.ChildNodes) `
+        -DocumentName $documentName `
+        -TransactionId $transactionId `
+        -RulePrefix $rulePrefix `
+        -SourceFile $relativeSource `
+        -Path $documentTerm `
+        -ParentCardinality '(root)' `
+        -ParentPrefix 'ubl' `
+        -ParentName $rootLocalName `
+        -Indexes $indexes `
+        -Rows $rows
+}
+
+$destination = Join-Path $repositoryRoot $OutputPath
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $destination) | Out-Null
+$rows | Sort-Object Document, Path | Export-Csv -NoTypeInformation -Encoding utf8 -Path $destination
+Write-Host "Wrote $($rows.Count) inferred-cardinality rows to $destination"
+
+$generatedDirectory = Join-Path $repositoryRoot $GeneratedSchematronDirectory
+$transactionIds = @($processedTransactionIds | Select-Object -Unique | Sort-Object)
+$generatedCoverageByTransaction = @{}
+foreach ($transactionId in $transactionIds) {
+    $generatedFile = Join-Path $generatedDirectory "$transactionId-basic.sch"
+    $generatedCoverageByTransaction[$transactionId] = Get-GeneratedMandatoryCoverage -GeneratedDirectory $generatedDirectory -TransactionId $transactionId
+    if (-not (Test-Path -LiteralPath $generatedFile)) {
+        Write-Warning "Generated Schematron not found: $generatedFile. Inferred rules for $transactionId will not be compared for exclusion."
+    }
+    else {
+        Write-Host "Loaded $($generatedCoverageByTransaction[$transactionId].Count) generated mandatory/existence asserts from $generatedFile"
+    }
+}
+
+$prefixCounters = @{}
+$exclusionRows = [System.Collections.Generic.List[object]]::new()
+$assertionRows = @(
+    $rows |
+        Where-Object { $_.NamespaceDiffersFromGeneratedMandatory -eq 'YES' -and $_.NamespaceCardinality -ne 'UNRESOLVED' } |
+        Sort-Object TransactionId, Path |
+        ForEach-Object {
+            if (-not $prefixCounters.ContainsKey($_.RulePrefix)) {
+                $prefixCounters[$_.RulePrefix] = 140
+            }
+
+            $id = "$($_.RulePrefix)-R$($prefixCounters[$_.RulePrefix])"
+            $prefixCounters[$_.RulePrefix]++
+            $pathSegments = $_.Path -split '/'
+            $context = ConvertTo-SchematronContext -ElementPath $_.Path
+            $child = $pathSegments[-1]
+            $coverageKey = "$(ConvertTo-NormalizedSchematronContext $context)|$child"
+            $generatedCoverage = $generatedCoverageByTransaction[$_.TransactionId]
+            $coveringAssert = if ($generatedCoverage -and $generatedCoverage.ContainsKey($coverageKey)) { $generatedCoverage[$coverageKey] } else { $null }
+
+            if ($coveringAssert) {
+                $reason = "Already covered by generated $($coveringAssert.Id) test='$($coveringAssert.Test)' [$($coveringAssert.StrictnessLabel)]."
+                Write-Host "Excluded $id $($_.Path): $reason"
+                $exclusionRows.Add([pscustomobject]@{
+                    TransactionId = $_.TransactionId
+                    InferredId = $id
+                    Path = $_.Path
+                    Context = $context
+                    Child = $child
+                    GeneratedId = $coveringAssert.Id
+                    GeneratedTest = $coveringAssert.Test
+                    Strictness = $coveringAssert.Strictness
+                    Reason = $reason
+                })
+                return
+            }
+
+            [pscustomobject]@{
+                Document = $_.Document
+                TransactionId = $_.TransactionId
+                RulePrefix = $_.RulePrefix
+                Id = $id
+                Context = $context
+                Child = $child
+            }
+        }
+)
+
+$exclusionDestination = Join-Path $repositoryRoot $ExclusionLogPath
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $exclusionDestination) | Out-Null
+$exclusionRows | Sort-Object TransactionId, InferredId | Export-Csv -NoTypeInformation -Encoding utf8 -Path $exclusionDestination
+Write-Host "Wrote $($exclusionRows.Count) inferred-cardinality exclusions to $exclusionDestination"
+
+$existenceCount = @($exclusionRows | Where-Object Strictness -eq 'existence').Count
+$repeatabilityCount = @($exclusionRows | Where-Object Strictness -eq 'repeatability').Count
+Write-Host "Exclusion strictness: $existenceCount existence only, $repeatabilityCount strict on repeatability (exactly one)."
+
+$schematronDirectory = Join-Path $repositoryRoot $SchematronOutputDirectory
+New-Item -ItemType Directory -Force -Path $schematronDirectory | Out-Null
+
+foreach ($transactionId in $transactionIds) {
+    $transactionAssertions = @($assertionRows | Where-Object TransactionId -eq $transactionId)
+    $transactionExclusions = @($exclusionRows | Where-Object TransactionId -eq $transactionId)
+    $schematronDestination = Join-Path $schematronDirectory "PEPPOL-M-$transactionId-I.sch"
+    $ruleCount = Write-InferredCardinalitySchematron -Path $schematronDestination -TransactionId $transactionId -AssertionRows $transactionAssertions
+    Write-Host "Wrote $($transactionAssertions.Count) cardinality assertions in $ruleCount parent-context rules to $schematronDestination (excluded $($transactionExclusions.Count) already covered by $transactionId-basic.sch)"
+}


### PR DESCRIPTION
Tested the script to determine missing inferred cardinality checks that are automaticaly build for upgrade.

None missing, but the schematron test is ony testing existance and not the 1..1, so it could happen that a 0..n in xsd slips through the cracks when it must become 1..1 check

Left it as is, no RFC's received on it yet